### PR TITLE
Feature/map logic for pr

### DIFF
--- a/app/src/main/java/com/moyeoyo/app/data/model/Vote.kt
+++ b/app/src/main/java/com/moyeoyo/app/data/model/Vote.kt
@@ -1,0 +1,30 @@
+package com.moyeoyo.app.data.model
+
+import com.google.firebase.firestore.GeoPoint
+
+/**
+ * 투표 상태를 관리하는 모델 (groups/{groupId}/vote 문서)
+ * Single Source of Truth - 모든 사용자가 이 문서를 보고 투표 상태를 확인
+ */
+data class Vote(
+    val status: String = "RANKING", // "RANKING", "FINAL_VOTING", "FINISHED"
+    val rankedUsers: List<String> = emptyList(), // 1차 순위 투표를 완료한 사용자 UID 목록
+    val finalCandidates: List<FinalCandidateData> = emptyList(), // 최종 후보 3개
+    val finalVotedUsers: List<String> = emptyList(), // 최종 투표를 완료한 사용자 UID 목록
+    val winningPlaceId: String? = null, // 승리한 장소의 placeId (FINISHED 상태일 때)
+    val winningPlaceName: String? = null // 승리한 장소의 이름 (FINISHED 상태일 때)
+)
+
+/**
+ * Firestore에 저장될 최종 후보 데이터 (FinalCandidate를 직렬화한 형태)
+ */
+data class FinalCandidateData(
+    val placeId: String,
+    val name: String,
+    val latLng: GeoPoint,
+    val totalScore: Int,
+    val categories: List<String> = emptyList(),
+    val rating: Double? = null,
+    val address: String? = null
+)
+

--- a/app/src/main/java/com/moyeoyo/app/data/repository/GroupRepository.kt
+++ b/app/src/main/java/com/moyeoyo/app/data/repository/GroupRepository.kt
@@ -635,4 +635,30 @@ class GroupRepository @Inject constructor(
             throw e
         }
     }
+    
+    /**
+     * 투표 상태를 RANKING으로 초기화 (이전 테스트 데이터 정리용)
+     * ⚠️ 주의: 이 함수는 테스트 중에만 사용하거나, 새로운 투표 세션을 시작할 때 사용해야 합니다.
+     */
+    suspend fun resetVoteStatus(groupId: String) {
+        try {
+            val voteRef = groupsCollection.document(groupId)
+                .collection("vote")
+                .document("vote")
+            
+            voteRef.update(
+                "status", "RANKING",
+                "rankedUsers", emptyList<String>(),
+                "finalCandidates", emptyList<Map<String, Any>>(),
+                "finalVotedUsers", emptyList<String>(),
+                "winningPlaceId", null,
+                "winningPlaceName", null
+            ).await()
+            
+            Log.d(TAG, "Vote status reset to RANKING for group $groupId")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to reset vote status: ${e.message}", e)
+            throw e
+        }
+    }
 }

--- a/app/src/main/java/com/moyeoyo/app/data/repository/GroupRepository.kt
+++ b/app/src/main/java/com/moyeoyo/app/data/repository/GroupRepository.kt
@@ -9,6 +9,7 @@ import com.google.firebase.Timestamp
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FieldPath
 import com.google.firebase.firestore.ListenerRegistration
+import com.google.firebase.firestore.Source
 import com.moyeoyo.app.data.model.Group
 import com.moyeoyo.app.data.model.Vote
 import com.moyeoyo.app.data.model.FinalCandidateData
@@ -491,7 +492,8 @@ class GroupRepository @Inject constructor(
             val voteRef = groupsCollection.document(groupId)
                 .collection("vote")
                 .document("vote")
-            val voteSnapshot = voteRef.get().await()
+            // ⚠️ Source.SERVER 추가하여 서버 데이터만 확인 (캐시 문제 방지)
+            val voteSnapshot = voteRef.get(Source.SERVER).await()
             
             @Suppress("UNCHECKED_CAST")
             val finalVotedUsers = voteSnapshot.get("finalVotedUsers") as? List<String> ?: emptyList()

--- a/app/src/main/java/com/moyeoyo/app/data/repository/GroupRepository.kt
+++ b/app/src/main/java/com/moyeoyo/app/data/repository/GroupRepository.kt
@@ -8,7 +8,13 @@ import com.google.firebase.firestore.GeoPoint
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FieldPath
+import com.google.firebase.firestore.ListenerRegistration
 import com.moyeoyo.app.data.model.Group
+import com.moyeoyo.app.data.model.Vote
+import com.moyeoyo.app.data.model.FinalCandidateData
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -69,7 +75,18 @@ class GroupRepository @Inject constructor(
                     "timestamp" to Timestamp.now()
                 )).await()
 
-            // 2. 모든 멤버의 users 문서에 groupId를 groups 배열에 추가 (일괄 쓰기 사용)
+            // 2. vote 하위 문서 생성 (투표 상태 관리용)
+            groupsCollection.document(groupId)
+                .collection("vote")
+                .document("vote")
+                .set(Vote(
+                    status = "RANKING",
+                    rankedUsers = emptyList(),
+                    finalCandidates = emptyList(),
+                    finalVotedUsers = emptyList()
+                )).await()
+
+            // 3. 모든 멤버의 users 문서에 groupId를 groups 배열에 추가 (일괄 쓰기 사용)
             val batch = db.batch()
             allMemberUids.forEach { uid ->
                 val userRef = usersCollection.document(uid)
@@ -77,7 +94,7 @@ class GroupRepository @Inject constructor(
             }
             batch.commit().await()
 
-            Log.d("GroupRepository", "Group created successfully with ID: $groupId, Members: ${allMemberUids.size}")
+            Log.d("GroupRepository", "Group created successfully with ID: $groupId, Members: ${allMemberUids.size}, Vote document created")
             groupId
         } catch (e: Exception) {
             Log.e("GroupRepository", "Group creation with members failed: ${e.message}", e)
@@ -341,5 +358,281 @@ class GroupRepository @Inject constructor(
             batch.delete(document.reference)
         }
         batch.commit().await()
+    }
+
+    // =========================
+    // Firestore: vote (투표 상태 관리)
+    // =========================
+
+    /**
+     * 1차 순위 투표 완료한 사용자를 rankedUsers 배열에 추가
+     */
+    suspend fun addUserToRankedList(groupId: String, uid: String) {
+        try {
+            val voteRef = groupsCollection.document(groupId)
+                .collection("vote")
+                .document("vote")
+            
+            voteRef.update("rankedUsers", FieldValue.arrayUnion(uid)).await()
+            Log.d(TAG, "User $uid added to rankedUsers for group $groupId")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to add user to rankedUsers: ${e.message}", e)
+            throw e
+        }
+    }
+
+    /**
+     * 모든 사용자가 1차 순위 투표를 완료했는지 확인
+     * @return true if all members have completed ranking, false otherwise
+     */
+    suspend fun checkAllUsersRanked(groupId: String): Boolean {
+        return try {
+            // 그룹 멤버 수 확인
+            val group = getGroupById(groupId) ?: return false
+            val totalMembers = group.memberUids.size
+
+            // vote 문서에서 rankedUsers 확인
+            val voteRef = groupsCollection.document(groupId)
+                .collection("vote")
+                .document("vote")
+            val voteSnapshot = voteRef.get().await()
+            
+            @Suppress("UNCHECKED_CAST")
+            val rankedUsers = voteSnapshot.get("rankedUsers") as? List<String> ?: emptyList()
+            
+            val allRanked = rankedUsers.size == totalMembers && 
+                           group.memberUids.all { it in rankedUsers }
+            
+            Log.d(TAG, "checkAllUsersRanked - groupId: $groupId, totalMembers: $totalMembers, rankedUsers: ${rankedUsers.size}, allRanked: $allRanked")
+            
+            allRanked
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to check all users ranked: ${e.message}", e)
+            false
+        }
+    }
+
+    /**
+     * 투표 상태 업데이트
+     */
+    suspend fun updateVoteStatus(groupId: String, status: String) {
+        try {
+            val voteRef = groupsCollection.document(groupId)
+                .collection("vote")
+                .document("vote")
+            
+            voteRef.update("status", status).await()
+            Log.d(TAG, "Vote status updated to $status for group $groupId")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to update vote status: ${e.message}", e)
+            throw e
+        }
+    }
+
+    /**
+     * 최종 후보 3개 업데이트 및 상태를 FINAL_VOTING으로 변경
+     */
+    suspend fun updateFinalCandidates(groupId: String, finalCandidates: List<FinalCandidateData>) {
+        try {
+            val voteRef = groupsCollection.document(groupId)
+                .collection("vote")
+                .document("vote")
+            
+            // finalCandidates를 Firestore에 저장할 수 있는 형태로 변환
+            val candidatesData = finalCandidates.map { candidate ->
+                mapOf(
+                    "placeId" to candidate.placeId,
+                    "name" to candidate.name,
+                    "latLng" to candidate.latLng,
+                    "totalScore" to candidate.totalScore,
+                    "categories" to candidate.categories,
+                    "rating" to (candidate.rating ?: ""),
+                    "address" to (candidate.address ?: "")
+                )
+            }
+            
+            voteRef.update(
+                "finalCandidates", candidatesData,
+                "status", "FINAL_VOTING"
+            ).await()
+            
+            Log.d(TAG, "Final candidates updated (${finalCandidates.size} items) and status changed to FINAL_VOTING for group $groupId")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to update final candidates: ${e.message}", e)
+            throw e
+        }
+    }
+
+    /**
+     * 최종 투표 완료한 사용자를 finalVotedUsers 배열에 추가
+     */
+    suspend fun addUserToFinalVotedList(groupId: String, uid: String) {
+        try {
+            val voteRef = groupsCollection.document(groupId)
+                .collection("vote")
+                .document("vote")
+            
+            voteRef.update("finalVotedUsers", FieldValue.arrayUnion(uid)).await()
+            Log.d(TAG, "User $uid added to finalVotedUsers for group $groupId")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to add user to finalVotedUsers: ${e.message}", e)
+            throw e
+        }
+    }
+
+    /**
+     * 모든 사용자가 최종 투표를 완료했는지 확인
+     */
+    suspend fun checkAllUsersFinalVoted(groupId: String): Boolean {
+        return try {
+            val group = getGroupById(groupId) ?: return false
+            val totalMembers = group.memberUids.size
+
+            val voteRef = groupsCollection.document(groupId)
+                .collection("vote")
+                .document("vote")
+            val voteSnapshot = voteRef.get().await()
+            
+            @Suppress("UNCHECKED_CAST")
+            val finalVotedUsers = voteSnapshot.get("finalVotedUsers") as? List<String> ?: emptyList()
+            
+            val allVoted = finalVotedUsers.size == totalMembers && 
+                          group.memberUids.all { it in finalVotedUsers }
+            
+            Log.d(TAG, "checkAllUsersFinalVoted - groupId: $groupId, totalMembers: $totalMembers, finalVotedUsers: ${finalVotedUsers.size}, allVoted: $allVoted")
+            
+            allVoted
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to check all users final voted: ${e.message}", e)
+            false
+        }
+    }
+
+    /**
+     * 투표 상태 조회
+     */
+    suspend fun getVoteStatus(groupId: String): Vote? {
+        return try {
+            val voteRef = groupsCollection.document(groupId)
+                .collection("vote")
+                .document("vote")
+            val snapshot = voteRef.get().await()
+            
+            if (snapshot.exists()) {
+                convertSnapshotToVote(snapshot)
+            } else {
+                Log.w(TAG, "Vote document not found for group $groupId")
+                null
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to get vote status: ${e.message}", e)
+            null
+        }
+    }
+
+    /**
+     * Firestore 스냅샷을 Vote 객체로 변환
+     */
+    private fun convertSnapshotToVote(snapshot: com.google.firebase.firestore.DocumentSnapshot): Vote {
+        val status = snapshot.get("status") as? String ?: "RANKING"
+        @Suppress("UNCHECKED_CAST")
+        val rankedUsers = (snapshot.get("rankedUsers") as? List<String>) ?: emptyList()
+        @Suppress("UNCHECKED_CAST")
+        val finalVotedUsers = (snapshot.get("finalVotedUsers") as? List<String>) ?: emptyList()
+        val winningPlaceId = snapshot.get("winningPlaceId") as? String
+        val winningPlaceName = snapshot.get("winningPlaceName") as? String
+        
+        // finalCandidates를 Map에서 FinalCandidateData로 변환
+        @Suppress("UNCHECKED_CAST")
+        val finalCandidatesData = (snapshot.get("finalCandidates") as? List<Map<String, Any>>)?.mapNotNull { map ->
+            try {
+                val placeId = map["placeId"] as? String ?: return@mapNotNull null
+                val name = map["name"] as? String ?: return@mapNotNull null
+                val latLng = when (val geo = map["latLng"]) {
+                    is GeoPoint -> geo
+                    is Map<*, *> -> {
+                        val lat = (geo["lat"] as? Number)?.toDouble() ?: (geo["latitude"] as? Number)?.toDouble()
+                        val lng = (geo["lng"] as? Number)?.toDouble() ?: (geo["longitude"] as? Number)?.toDouble()
+                        if (lat != null && lng != null) GeoPoint(lat, lng) else return@mapNotNull null
+                    }
+                    else -> return@mapNotNull null
+                }
+                val totalScore = (map["totalScore"] as? Number)?.toInt() ?: return@mapNotNull null
+                @Suppress("UNCHECKED_CAST")
+                val categories = (map["categories"] as? List<String>) ?: emptyList()
+                val rating = when (val ratingValue = map["rating"]) {
+                    is Number -> ratingValue.toDouble()
+                    is String -> if (ratingValue.isNotEmpty()) ratingValue.toDoubleOrNull() else null
+                    else -> null
+                }
+                val address = map["address"] as? String
+                
+                FinalCandidateData(
+                    placeId = placeId,
+                    name = name,
+                    latLng = latLng,
+                    totalScore = totalScore,
+                    categories = categories,
+                    rating = rating,
+                    address = address
+                )
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to convert finalCandidate data: ${e.message}", e)
+                null
+            }
+        } ?: emptyList()
+        
+        return Vote(
+            status = status,
+            rankedUsers = rankedUsers,
+            finalCandidates = finalCandidatesData,
+            finalVotedUsers = finalVotedUsers,
+            winningPlaceId = winningPlaceId,
+            winningPlaceName = winningPlaceName
+        )
+    }
+
+    /**
+     * 투표 상태 실시간 리스너 (Flow로 반환)
+     */
+    fun listenToVoteStatus(groupId: String): Flow<Vote?> = callbackFlow {
+        val voteRef = groupsCollection.document(groupId)
+            .collection("vote")
+            .document("vote")
+        
+        val listener = voteRef.addSnapshotListener { snapshot, error ->
+            if (error != null) {
+                Log.e(TAG, "Error listening to vote status: ${error.message}", error)
+                trySend(null)
+                return@addSnapshotListener
+            }
+            
+            val vote = snapshot?.let { convertSnapshotToVote(it) }
+            trySend(vote)
+        }
+        
+        awaitClose { listener.remove() }
+    }
+
+    /**
+     * 승리한 장소로 투표 상태 완료 처리
+     */
+    suspend fun setWinningPlace(groupId: String, placeId: String, placeName: String) {
+        try {
+            val voteRef = groupsCollection.document(groupId)
+                .collection("vote")
+                .document("vote")
+            
+            voteRef.update(
+                "winningPlaceId", placeId,
+                "winningPlaceName", placeName,
+                "status", "FINISHED"
+            ).await()
+            
+            Log.d(TAG, "Winning place set: $placeName ($placeId) for group $groupId, status changed to FINISHED")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to set winning place: ${e.message}", e)
+            throw e
+        }
     }
 }

--- a/app/src/main/java/com/moyeoyo/app/data/repository/MapRepository.kt
+++ b/app/src/main/java/com/moyeoyo/app/data/repository/MapRepository.kt
@@ -591,6 +591,175 @@ class MapRepository @Inject constructor(
         return ref.id
     }
 
+    /**
+     * 기존 장소 후보 모두 삭제 (새로운 투표 세션 시작 전)
+     */
+    suspend fun clearPlaceCandidates(groupId: String) {
+        val candidatesRef = firestore.collection("groups")
+            .document(groupId)
+            .collection("placeCandidates")
+        
+        // 배치로 삭제
+        var batch = firestore.batch()
+        var count = 0
+        val batchSize = 500
+        
+        candidatesRef.get().await().documents.forEach { doc ->
+            if (count < batchSize) {
+                batch.delete(doc.reference)
+                count++
+            } else {
+                batch.commit().await()
+                batch = firestore.batch()
+                batch.delete(doc.reference)
+                count = 1
+            }
+        }
+        
+        if (count > 0) {
+            batch.commit().await()
+        }
+    }
+
+    // =========================
+    // Firestore: userRankings (사용자별 순위 지정)
+    // =========================
+
+    /**
+     * 사용자별 순위 지정 저장 (groups/{groupId}/userRankings/{uid})
+     * @param rankedPlaces 사용자가 선택한 3개 장소의 순위 리스트
+     */
+    suspend fun saveUserRankings(groupId: String, rankedPlaces: List<com.moyeoyo.app.data.model.RankedPlace>) {
+        val uid = currentUid() ?: throw IllegalStateException("사용자가 로그인되어 있지 않습니다.")
+        
+        val data = mutableMapOf<String, Any>(
+            "uid" to uid,
+            "timestamp" to com.google.firebase.firestore.FieldValue.serverTimestamp(),
+            "rankedPlaces" to rankedPlaces.map { rankedPlace ->
+                val placeMap = mutableMapOf<String, Any>(
+                    "placeId" to rankedPlace.place.placeId,
+                    "name" to rankedPlace.place.name,
+                    "latLng" to com.google.firebase.firestore.GeoPoint(
+                        rankedPlace.place.latLng.lat,
+                        rankedPlace.place.latLng.lng
+                    ),
+                    "rank" to rankedPlace.rank,
+                    "score" to rankedPlace.score,
+                    "categories" to (rankedPlace.place.categories ?: emptyList()),
+                    "distanceMeters" to rankedPlace.place.distanceMeters
+                )
+                // 평점과 주소는 null일 수 있으므로 조건부로 추가
+                rankedPlace.place.rating?.let { placeMap["rating"] = it }
+                rankedPlace.place.address?.let { placeMap["address"] = it }
+                placeMap
+            }
+        )
+        
+        firestore.collection("groups")
+            .document(groupId)
+            .collection("userRankings")
+            .document(uid)
+            .set(data)
+            .await()
+    }
+
+    /**
+     * 특정 사용자의 순위 지정 조회
+     */
+    suspend fun getUserRankings(
+        groupId: String, 
+        uid: String,
+        source: com.google.firebase.firestore.Source = com.google.firebase.firestore.Source.DEFAULT
+    ): List<com.moyeoyo.app.data.model.RankedPlace> {
+        val doc = firestore.collection("groups")
+            .document(groupId)
+            .collection("userRankings")
+            .document(uid)
+            .get(source)
+            .await()
+        
+        if (!doc.exists()) return emptyList()
+        
+        val data = doc.data ?: return emptyList()
+        @Suppress("UNCHECKED_CAST")
+        val rankedPlacesList = data["rankedPlaces"] as? List<Map<String, Any>> ?: return emptyList()
+        
+        return rankedPlacesList.mapNotNull { placeMap ->
+            val placeId = placeMap["placeId"] as? String ?: return@mapNotNull null
+            val name = placeMap["name"] as? String ?: return@mapNotNull null
+            val rank = (placeMap["rank"] as? Number)?.toInt() ?: return@mapNotNull null
+            val score = (placeMap["score"] as? Number)?.toInt() ?: return@mapNotNull null
+            
+            val latLng = when (val geo = placeMap["latLng"]) {
+                is GeoPoint -> LatLngData(geo.latitude, geo.longitude)
+                is Map<*, *> -> {
+                    val lat = (geo["lat"] as? Number)?.toDouble() ?: (geo["latitude"] as? Number)?.toDouble()
+                    val lng = (geo["lng"] as? Number)?.toDouble() ?: (geo["longitude"] as? Number)?.toDouble()
+                    if (lat != null && lng != null) LatLngData(lat, lng) else return@mapNotNull null
+                }
+                else -> return@mapNotNull null
+            }
+            
+            // 저장된 평점, 카테고리, 주소, 거리 정보 불러오기
+            @Suppress("UNCHECKED_CAST")
+            val categories = (placeMap["categories"] as? List<String>) ?: emptyList()
+            val rating = (placeMap["rating"] as? Number)?.toDouble()
+            val address = placeMap["address"] as? String
+            val distanceMeters = (placeMap["distanceMeters"] as? Number)?.toDouble() ?: 0.0
+            
+            val place = NearbyPlace(
+                placeId = placeId,
+                name = name,
+                address = address,
+                latLng = latLng,
+                categories = categories,
+                rating = rating,
+                distanceMeters = distanceMeters
+            )
+            
+            com.moyeoyo.app.data.model.RankedPlace(place, rank, score)
+        }
+    }
+
+    /**
+     * 모든 사용자의 순위 지정 조회
+     * Source.SERVER를 사용하여 서버에서 직접 가져오기 (캐시 무시)
+     */
+    suspend fun getAllUserRankings(groupId: String): Map<String, List<com.moyeoyo.app.data.model.RankedPlace>> {
+        val snap = firestore.collection("groups")
+            .document(groupId)
+            .collection("userRankings")
+            .get(com.google.firebase.firestore.Source.SERVER)
+            .await()
+        
+        android.util.Log.d("MapRepository", 
+            "📥 모든 사용자 순위 조회 - groupId: $groupId, 문서 수: ${snap.documents.size}")
+        
+        return snap.documents.associate { doc ->
+            val uid = doc.id
+            // Source.SERVER를 사용하여 서버에서 직접 가져오기 (캐시 무시)
+            val rankedPlaces = getUserRankings(groupId, uid, com.google.firebase.firestore.Source.SERVER)
+            android.util.Log.d("MapRepository", 
+                "  - 사용자 $uid: ${rankedPlaces.size}개 순위 지정")
+            uid to rankedPlaces
+        }
+    }
+
+    /**
+     * 순위 지정 완료한 사용자 수 확인
+     */
+    suspend fun getCompletedRankingCount(groupId: String): Int {
+        // Source.SERVER를 사용하여 서버에서 직접 가져오기 (캐시 무시)
+        val snap = firestore.collection("groups")
+            .document(groupId)
+            .collection("userRankings")
+            .get(com.google.firebase.firestore.Source.SERVER)
+            .await()
+        val count = snap.documents.size
+        android.util.Log.d("MapRepository", "✅ 완료된 순위 지정 수: $count, groupId: $groupId")
+        return count
+    }
+
     suspend fun votePlaceCandidate(groupId: String, candidateId: String, uid: String) {
         firestore.collection("groups")
             .document(groupId)

--- a/app/src/main/java/com/moyeoyo/app/map/MapViewModel.kt
+++ b/app/src/main/java/com/moyeoyo/app/map/MapViewModel.kt
@@ -28,6 +28,12 @@ class MapViewModel @Inject constructor(
     private val _state = MutableLiveData(MapState())
     val state: LiveData<MapState> = _state
 
+    // 최종 확정 모드 여부 (최종 투표로 확정된 장소 표시 모드)
+    private val _isFinalized = MutableLiveData<Boolean>(false)
+    val isFinalized: LiveData<Boolean> = _isFinalized
+
+    private var isMapReady = false
+
     // 상태 업데이트 헬퍼
     // - 기존 상태를 받아 변경된 상태를 생성해 LiveData에 반영
     private fun update(block: (MapState) -> MapState) {
@@ -361,6 +367,69 @@ class MapViewModel @Inject constructor(
         }
         update { it.copy(selectedPlace = place, error = null) }
         computeDistancesByMode(members, place.latLng)
+    }
+
+    /**
+     * 최종 확정 모드로 전환 (최종 투표로 확정된 장소 표시)
+     * @param place 최종 확정된 장소
+     */
+    fun setFinalizedMode(place: NearbyPlace) {
+        _isFinalized.value = true
+        update { it.copy(selectedPlace = place, error = null) }
+        Log.d("MapViewModel", "✅ 최종 장소 모드 설정: ${place.name}")
+        
+        // 멤버가 이미 로드되어 있으면 거리 계산
+        val currentState = _state.value
+        val members = currentState?.members ?: emptyList()
+        if (members.isNotEmpty()) {
+            computeDistancesByMode(members, place.latLng)
+        } else {
+            // 멤버가 없으면 그룹 멤버 로드 후 거리 계산
+            val groupId = currentState?.groupId
+            if (!groupId.isNullOrBlank()) {
+                loadGroupMembersAndComputeDistances(groupId, place.latLng)
+            }
+        }
+    }
+
+    /**
+     * 지도 준비 완료 알림
+     */
+    fun onMapReady() {
+        isMapReady = true
+        // 지도가 준비되면 최종 모드인 경우 멤버 로드 및 거리 계산
+        val currentState = _state.value
+        if (_isFinalized.value == true && currentState?.selectedPlace != null) {
+            val groupId = currentState.groupId
+            val place = currentState.selectedPlace!!
+            if (!groupId.isNullOrBlank() && currentState.members.isEmpty()) {
+                loadGroupMembersAndComputeDistances(groupId, place.latLng)
+            } else if (currentState.members.isNotEmpty()) {
+                computeDistancesByMode(currentState.members, place.latLng)
+            }
+        }
+    }
+
+    /**
+     * 그룹 멤버 로드 후 특정 목적지까지의 거리 계산
+     */
+    private fun loadGroupMembersAndComputeDistances(groupId: String, destination: LatLngData) {
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                val members = repo.getInputLocations(groupId)
+                Log.d("MapViewModel", "Firestore에서 가져온 멤버 수: ${members.size}명")
+                
+                withContext(Dispatchers.Main) {
+                    update { it.copy(members = members) }
+                    computeDistancesByMode(members, destination)
+                }
+            } catch (e: Exception) {
+                Log.e("MapViewModel", "멤버 로드 실패: ${e.message}", e)
+                withContext(Dispatchers.Main) {
+                    update { it.copy(error = e.message, isLoading = false) }
+                }
+            }
+        }
     }
 
     fun computeTravelTimesForSelectedPlace() {

--- a/app/src/main/java/com/moyeoyo/app/map/MapViewModel.kt
+++ b/app/src/main/java/com/moyeoyo/app/map/MapViewModel.kt
@@ -33,6 +33,7 @@ class MapViewModel @Inject constructor(
     val isFinalized: LiveData<Boolean> = _isFinalized
 
     private var isMapReady = false
+    private var isLoadingMembers = false // 멤버 로드 중복 호출 방지 플래그
 
     // 상태 업데이트 헬퍼
     // - 기존 상태를 받아 변경된 상태를 생성해 LiveData에 반영
@@ -383,13 +384,9 @@ class MapViewModel @Inject constructor(
         val members = currentState?.members ?: emptyList()
         if (members.isNotEmpty()) {
             computeDistancesByMode(members, place.latLng)
-        } else {
-            // 멤버가 없으면 그룹 멤버 로드 후 거리 계산
-            val groupId = currentState?.groupId
-            if (!groupId.isNullOrBlank()) {
-                loadGroupMembersAndComputeDistances(groupId, place.latLng)
-            }
         }
+        // ⚠️ 멤버가 없어도 여기서는 로드하지 않음 - onMapReady에서 처리
+        // 이렇게 하면 setFinalizedMode와 onMapReady의 중복 호출을 방지할 수 있음
     }
 
     /**
@@ -402,10 +399,13 @@ class MapViewModel @Inject constructor(
         if (_isFinalized.value == true && currentState?.selectedPlace != null) {
             val groupId = currentState.groupId
             val place = currentState.selectedPlace!!
-            if (!groupId.isNullOrBlank() && currentState.members.isEmpty()) {
-                loadGroupMembersAndComputeDistances(groupId, place.latLng)
-            } else if (currentState.members.isNotEmpty()) {
-                computeDistancesByMode(currentState.members, place.latLng)
+            if (!groupId.isNullOrBlank()) {
+                // 멤버가 없으면 로드, 있으면 거리만 계산
+                if (currentState.members.isEmpty()) {
+                    loadGroupMembersAndComputeDistances(groupId, place.latLng)
+                } else {
+                    computeDistancesByMode(currentState.members, place.latLng)
+                }
             }
         }
     }
@@ -414,6 +414,13 @@ class MapViewModel @Inject constructor(
      * 그룹 멤버 로드 후 특정 목적지까지의 거리 계산
      */
     private fun loadGroupMembersAndComputeDistances(groupId: String, destination: LatLngData) {
+        // 중복 호출 방지
+        if (isLoadingMembers) {
+            Log.d("MapViewModel", "⏸️ 이미 멤버 로드 중 - 중복 호출 방지")
+            return
+        }
+        
+        isLoadingMembers = true
         viewModelScope.launch(Dispatchers.IO) {
             try {
                 val members = repo.getInputLocations(groupId)
@@ -422,11 +429,13 @@ class MapViewModel @Inject constructor(
                 withContext(Dispatchers.Main) {
                     update { it.copy(members = members) }
                     computeDistancesByMode(members, destination)
+                    isLoadingMembers = false
                 }
             } catch (e: Exception) {
                 Log.e("MapViewModel", "멤버 로드 실패: ${e.message}", e)
                 withContext(Dispatchers.Main) {
                     update { it.copy(error = e.message, isLoading = false) }
+                    isLoadingMembers = false
                 }
             }
         }

--- a/app/src/main/java/com/moyeoyo/app/map/MidpointActivity.kt
+++ b/app/src/main/java/com/moyeoyo/app/map/MidpointActivity.kt
@@ -49,8 +49,6 @@ class MidpointActivity : AppCompatActivity(), OnMapReadyCallback {
     private var pendingTravelTimesDialog = false
     private var pendingNearbyDialog = false
     private var googleMap: GoogleMap? = null
-    private var isMapReady = false
-    private var pendingWinningPlace: com.moyeoyo.app.data.model.NearbyPlace? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -74,32 +72,33 @@ class MidpointActivity : AppCompatActivity(), OnMapReadyCallback {
         setupViews()
         observe()
 
-        // Intent로 groupId가 전달된 경우 자동으로 데이터 로드
-        if (intent.hasExtra("groupId")) {
-            viewModel.loadGroupMembers(groupId)
-        }
-        
-        // Intent로 승리한 장소가 전달된 경우 selectedPlace로 설정
+        // ⭐ Intent 처리: 최종 확정 장소가 있으면 최종 모드로, 없으면 중간 지점 계산 모드로
         val selectedPlaceId = intent.getStringExtra("selectedPlaceId")
-        val selectedPlaceName = intent.getStringExtra("selectedPlaceName")
-        val selectedPlaceLat = intent.getDoubleExtra("selectedPlaceLat", 0.0)
-        val selectedPlaceLng = intent.getDoubleExtra("selectedPlaceLng", 0.0)
-        
-        if (selectedPlaceId != null && selectedPlaceName != null && 
-            selectedPlaceLat != 0.0 && selectedPlaceLng != 0.0) {
-            // NearbyPlace 생성 및 선택
-            val winningPlace = com.moyeoyo.app.data.model.NearbyPlace(
-                placeId = selectedPlaceId,
-                name = selectedPlaceName,
-                address = null,
-                latLng = com.moyeoyo.app.data.model.LatLngData(selectedPlaceLat, selectedPlaceLng),
-                categories = emptyList(),
-                rating = null,
-                distanceMeters = 0.0
-            )
+        if (selectedPlaceId != null) {
+            // 최종 확정 장소가 있으면 최종 모드로 전환
+            val selectedPlaceName = intent.getStringExtra("selectedPlaceName") ?: "알 수 없는 장소"
+            val selectedPlaceAddress = intent.getStringExtra("selectedPlaceAddress")
+            val selectedPlaceLat = intent.getDoubleExtra("selectedPlaceLat", 0.0)
+            val selectedPlaceLng = intent.getDoubleExtra("selectedPlaceLng", 0.0)
             
-            // 그룹 멤버 로드 후 승리한 장소 선택 (observe 함수 내에서 처리)
-            pendingWinningPlace = winningPlace
+            if (selectedPlaceLat != 0.0 && selectedPlaceLng != 0.0) {
+                val winningPlace = com.moyeoyo.app.data.model.NearbyPlace(
+                    placeId = selectedPlaceId,
+                    name = selectedPlaceName,
+                    address = selectedPlaceAddress,
+                    latLng = com.moyeoyo.app.data.model.LatLngData(selectedPlaceLat, selectedPlaceLng),
+                    categories = emptyList(),
+                    rating = null,
+                    distanceMeters = 0.0
+                )
+                // ViewModel에게 최종 모드로 전환하라고 알림
+                viewModel.setFinalizedMode(winningPlace)
+            }
+        } else {
+            // 최종 확정 장소가 없으면 중간 지점 계산 모드로 시작
+            if (intent.hasExtra("groupId")) {
+                viewModel.loadGroupMembers(groupId)
+            }
         }
     }
 
@@ -126,28 +125,15 @@ class MidpointActivity : AppCompatActivity(), OnMapReadyCallback {
 
     private fun observe() {
         viewModel.state.observe(this) { s ->
-            // 중간지점 표시
-            s.weightedCenter?.let { center ->
-                binding.tvMidpointCoords.text = "위도: %.6f° / 경도: %.6f°".format(center.lat, center.lng)
-                // 주소 가져오기
-                getAddressFromLocation(center) { address ->
-                    binding.tvMidpointAddress.text = address
-                }
-            }
+            // ⭐ ViewModel의 isFinalized 상태에 따라 UI 업데이트
+            val isFinalized = viewModel.isFinalized.value == true
+            updateUIForMode(isFinalized, s)
 
             // 멤버별 소요시간 표시
             if (s.distanceByMember.isNotEmpty()) {
                 bindMemberDistances(s)
             } else if (adapter.itemCount != 0) {
                 adapter.submitList(emptyList())
-            }
-            
-            // 승리한 장소 선택 (멤버 로드 후 한 번만 실행)
-            pendingWinningPlace?.let { winningPlace ->
-                if (s.members.isNotEmpty()) {
-                    viewModel.selectNearbyPlace(winningPlace)
-                    pendingWinningPlace = null // 한 번만 실행되도록 null로 설정
-                }
             }
 
             // 주변 장소 필터링 화면으로 이동
@@ -181,6 +167,43 @@ class MidpointActivity : AppCompatActivity(), OnMapReadyCallback {
             }
 
             updateMapMarkers(s)
+        }
+    }
+
+    /**
+     * 최종 모드 여부에 따라 UI 업데이트
+     */
+    private fun updateUIForMode(isFinalized: Boolean, state: MapState) {
+        if (isFinalized) {
+            // 최종 확정된 약속 장소 정보 표시
+            binding.tvMidpointTitle.text = "최종 확정된 약속 장소"
+            state.selectedPlace?.let { place ->
+                binding.tvMidpointAddress.text = place.name
+                if (!place.address.isNullOrBlank()) {
+                    binding.tvMidpointCoords.text = place.address
+                } else {
+                    binding.tvMidpointCoords.text = "위도: %.6f° / 경도: %.6f°".format(
+                        place.latLng.lat, 
+                        place.latLng.lng
+                    )
+                }
+            } ?: run {
+                binding.tvMidpointAddress.text = "장소 정보를 불러오는 중..."
+                binding.tvMidpointCoords.text = ""
+            }
+        } else {
+            // 중간지점 표시
+            binding.tvMidpointTitle.text = "계산된 중간 지점"
+            state.weightedCenter?.let { center ->
+                binding.tvMidpointCoords.text = "위도: %.6f° / 경도: %.6f°".format(center.lat, center.lng)
+                // 주소 가져오기
+                getAddressFromLocation(center) { address ->
+                    binding.tvMidpointAddress.text = address
+                }
+            } ?: run {
+                binding.tvMidpointAddress.text = "중간 지점을 계산 중입니다..."
+                binding.tvMidpointCoords.text = ""
+            }
         }
     }
 
@@ -219,13 +242,33 @@ class MidpointActivity : AppCompatActivity(), OnMapReadyCallback {
 
     override fun onMapReady(map: GoogleMap) {
         googleMap = map
-        isMapReady = true
         map.uiSettings.isZoomControlsEnabled = true
+        
+        // ⭐ ViewModel에 지도 준비 완료를 알림
+        viewModel.onMapReady()
+        
+        // 마커 클릭 리스너 설정
+        map.setOnMarkerClickListener { marker ->
+            // 최종 확정된 장소 마커인지 확인
+            val isFinalized = viewModel.isFinalized.value == true
+            val selectedPlace = viewModel.state.value?.selectedPlace
+            
+            if (isFinalized && selectedPlace != null && 
+                marker.position.latitude == selectedPlace.latLng.lat && 
+                marker.position.longitude == selectedPlace.latLng.lng) {
+                // 최종 확정된 장소 마커 클릭 시 정보 표시
+                marker.showInfoWindow()
+                true // 이벤트 소비
+            } else {
+                false // 기본 동작 수행
+            }
+        }
+        
+        // 지도가 준비되면 현재 상태로 마커 업데이트
         viewModel.state.value?.let { updateMapMarkers(it) }
     }
 
     private fun updateMapMarkers(state: MapState) {
-        if (!isMapReady) return
         val map = googleMap ?: return
         map.clear()
 
@@ -245,28 +288,45 @@ class MidpointActivity : AppCompatActivity(), OnMapReadyCallback {
             hasPoint = true
         }
 
-        state.weightedCenter?.let { center ->
-            val position = LatLng(center.lat, center.lng)
-            map.addMarker(
-                MarkerOptions()
-                    .position(position)
-                    .title(getString(R.string.center_marker_title))
-                    .icon(BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_AZURE))
-            )
-            builder.include(position)
-            hasPoint = true
-        }
-
-        state.selectedPlace?.let { place ->
-            val position = LatLng(place.latLng.lat, place.latLng.lng)
-        map.addMarker(
-            MarkerOptions()
-                    .position(position)
-                    .title(place.name)
-                    .icon(BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_GREEN))
-            )
-            builder.include(position)
-            hasPoint = true
+        // ⭐ 최종 모드 여부에 따라 마커 표시 분기
+        val isFinalized = viewModel.isFinalized.value == true
+        
+        if (isFinalized) {
+            // 최종 모드: 최종 확정된 장소에 빨간색 마커 표시
+            state.selectedPlace?.let { place ->
+                val position = LatLng(place.latLng.lat, place.latLng.lng)
+                android.util.Log.d("MidpointActivity", 
+                    "✅ 승리한 장소 마커 추가: ${place.name}, 위치: (${place.latLng.lat}, ${place.latLng.lng}), 주소: ${place.address}")
+                val marker = map.addMarker(
+                    MarkerOptions()
+                        .position(position)
+                        .title(place.name)
+                        .snippet(place.address ?: "최종 확정된 장소")
+                        .icon(BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_RED))
+                )
+                if (marker != null) {
+                    android.util.Log.d("MidpointActivity", "✅ 빨간색 마커 추가 성공")
+                } else {
+                    android.util.Log.e("MidpointActivity", "❌ 마커 추가 실패")
+                }
+                builder.include(position)
+                hasPoint = true
+            } ?: run {
+                android.util.Log.d("MidpointActivity", "⏸️ 최종 모드이지만 selectedPlace가 null입니다")
+            }
+        } else {
+            // 중간 지점 모드: 중간 지점에 파란색 마커 표시
+            state.weightedCenter?.let { center ->
+                val position = LatLng(center.lat, center.lng)
+                map.addMarker(
+                    MarkerOptions()
+                        .position(position)
+                        .title(getString(R.string.center_marker_title))
+                        .icon(BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_AZURE))
+                )
+                builder.include(position)
+                hasPoint = true
+            }
         }
 
         if (hasPoint) {

--- a/app/src/main/java/com/moyeoyo/app/ui/location/LocationInputActivity.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/location/LocationInputActivity.kt
@@ -106,26 +106,46 @@ class LocationInputActivity : AppCompatActivity() {
 
         // 현재 위치 버튼
         findViewById<View>(R.id.btn_use_current_location).setOnClickListener {
+            if (isLocationInputLocked()) {
+                Toast.makeText(this, "중간값 계산이 완료되어 위치를 변경할 수 없습니다.", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            }
             requestLocationPermission()
         }
 
         // 집 버튼
         findViewById<View>(R.id.btn_use_home).setOnClickListener {
+            if (isLocationInputLocked()) {
+                Toast.makeText(this, "중간값 계산이 완료되어 위치를 변경할 수 없습니다.", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            }
             loadHomeLocation()
         }
 
         // 회사 버튼
         findViewById<View>(R.id.btn_use_work).setOnClickListener {
+            if (isLocationInputLocked()) {
+                Toast.makeText(this, "중간값 계산이 완료되어 위치를 변경할 수 없습니다.", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            }
             loadWorkLocation()
         }
 
         // 검색창 클릭
         findViewById<View>(R.id.layoutSearchBar).setOnClickListener {
+            if (isLocationInputLocked()) {
+                Toast.makeText(this, "중간값 계산이 완료되어 위치를 변경할 수 없습니다.", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            }
             openPlacesAutocomplete()
         }
 
         // 위치 저장 버튼
         findViewById<View>(R.id.btn_save_location).setOnClickListener {
+            if (isLocationInputLocked()) {
+                Toast.makeText(this, "중간값 계산이 완료되어 위치를 변경할 수 없습니다.", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            }
             if (selectedLocation != null) {
                 saveMyLocationToFirestore()
             } else {
@@ -507,7 +527,13 @@ class LocationInputActivity : AppCompatActivity() {
                 val missingUids = memberUids.filter { it !in inputtedUids }
 
                 withContext(Dispatchers.Main) {
+                    // 모든 사용자가 위치를 저장했으면 위치 입력 잠금
+                    if (allInputted) {
+                        isLocationLocked = true
+                    }
                     updateUIForInputStatus(allInputted, missingUids)
+                    // 잠금 상태에 따라 UI 업데이트
+                    updateUIForLockedState(isLocationLocked)
                 }
             } catch (e: Exception) {
                 Log.e("LocationInput", "입력 상태 확인 실패: ${e.message}")
@@ -581,6 +607,58 @@ class LocationInputActivity : AppCompatActivity() {
                     Toast.makeText(this@LocationInputActivity, "위치 저장에 실패했습니다: ${e.message}", Toast.LENGTH_SHORT).show()
                 }
             }
+        }
+    }
+
+    private var isLocationLocked = false // 위치 입력 잠금 상태
+
+    /**
+     * 중간값 계산이 완료되어 위치 입력이 잠겨있는지 확인
+     * vote 문서의 상태가 RANKING 이상이면 위치 변경 불가
+     */
+    private fun isLocationInputLocked(): Boolean {
+        return isLocationLocked
+    }
+
+
+    /**
+     * 위치 입력이 잠겨있을 때 UI 업데이트
+     */
+    private fun updateUIForLockedState(isLocked: Boolean) {
+        val currentLocationBtn = findViewById<View>(R.id.btn_use_current_location)
+        val homeBtn = findViewById<View>(R.id.btn_use_home)
+        val workBtn = findViewById<View>(R.id.btn_use_work)
+        val searchBar = findViewById<View>(R.id.layoutSearchBar)
+        val saveBtn = findViewById<View>(R.id.btn_save_location)
+        val infoTextView = findViewById<android.widget.TextView>(R.id.location_input_info)
+        
+        if (isLocked) {
+            // 버튼 비활성화
+            currentLocationBtn.isEnabled = false
+            currentLocationBtn.alpha = 0.5f
+            homeBtn.isEnabled = false
+            homeBtn.alpha = 0.5f
+            workBtn.isEnabled = false
+            workBtn.alpha = 0.5f
+            searchBar.isEnabled = false
+            searchBar.alpha = 0.5f
+            saveBtn.isEnabled = false
+            saveBtn.alpha = 0.5f
+            
+            // 안내 메시지 표시
+            infoTextView.text = "중간값 계산이 완료되어 위치를 변경할 수 없습니다."
+        } else {
+            // 버튼 활성화
+            currentLocationBtn.isEnabled = true
+            currentLocationBtn.alpha = 1f
+            homeBtn.isEnabled = true
+            homeBtn.alpha = 1f
+            workBtn.isEnabled = true
+            workBtn.alpha = 1f
+            searchBar.isEnabled = true
+            searchBar.alpha = 1f
+            saveBtn.isEnabled = true
+            saveBtn.alpha = 1f
         }
     }
 }

--- a/app/src/main/java/com/moyeoyo/app/ui/place/FinalCandidateAdapter.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/place/FinalCandidateAdapter.kt
@@ -23,6 +23,26 @@ class FinalCandidateAdapter(
     private val onCandidateClick: (FinalCandidate) -> Unit
 ) : ListAdapter<FinalCandidate, FinalCandidateAdapter.CandidateViewHolder>(CandidateDiffCallback()) {
 
+    private var transitTimes: Map<String, Int> = emptyMap() // placeId -> 대중교통 소요시간 (초)
+
+    /**
+     * 소요시간 업데이트 (스크롤 위치 유지)
+     */
+    fun updateTransitTimes(newTransitTimes: Map<String, Int>) {
+        val oldTransitTimes = transitTimes
+        transitTimes = newTransitTimes
+        
+        // 변경된 아이템만 찾아서 업데이트
+        for (i in 0 until itemCount) {
+            val candidate = getItem(i)
+            val oldTime = oldTransitTimes[candidate.place.placeId]
+            val newTime = newTransitTimes[candidate.place.placeId]
+            if (oldTime != newTime) {
+                notifyItemChanged(i)
+            }
+        }
+    }
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CandidateViewHolder {
         val binding = ItemFinalCandidateBinding.inflate(
             LayoutInflater.from(parent.context),
@@ -53,9 +73,21 @@ class FinalCandidateAdapter(
                 binding.tvRating.text = "★ -"
             }
 
-            // 거리 표시
+            // 거리 및 대중교통 시간 표시
             val distanceKm = candidate.place.distanceMeters / 1000.0
-            binding.tvDistance.text = String.format(Locale.getDefault(), "%.1fkm", distanceKm)
+            val transitTimeSeconds = transitTimes[candidate.place.placeId]
+            
+            if (transitTimeSeconds != null) {
+                val transitTimeMinutes = (transitTimeSeconds / 60.0).toInt().coerceAtLeast(1)
+                binding.tvDistance.text = String.format(
+                    Locale.getDefault(), 
+                    "평균 %.1fkm · 대중교통 %d분", 
+                    distanceKm, 
+                    transitTimeMinutes
+                )
+            } else {
+                binding.tvDistance.text = String.format(Locale.getDefault(), "%.1fkm", distanceKm)
+            }
 
             // 선택된 표시
             binding.tvSelected.visibility = if (candidate.isSelected) View.VISIBLE else View.GONE

--- a/app/src/main/java/com/moyeoyo/app/ui/place/FinalVoteActivity.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/place/FinalVoteActivity.kt
@@ -207,11 +207,12 @@ class FinalVoteActivity : AppCompatActivity() {
             .setTitle("최종 약속 장소 확정")
             .setMessage("최종 약속 장소는 \"${winningPlace.name}\"로 선정되었습니다.\n중간값 계산 화면으로 이동하여 소요시간을 확인하시겠습니까?")
             .setPositiveButton("확인") { _, _ ->
-                // 중간값 계산 화면으로 이동하며 승리한 장소 전달
+                // 중간값 계산 화면으로 이동하며 승리한 장소 전달 (주소 포함)
                 val intent = Intent(this, MidpointActivity::class.java).apply {
                     putExtra("groupId", groupId)
                     putExtra("selectedPlaceId", winningPlace.placeId)
                     putExtra("selectedPlaceName", winningPlace.name)
+                    putExtra("selectedPlaceAddress", winningPlace.address)
                     putExtra("selectedPlaceLat", winningPlace.latLng.lat)
                     putExtra("selectedPlaceLng", winningPlace.latLng.lng)
                 }

--- a/app/src/main/java/com/moyeoyo/app/ui/place/FinalVoteActivity.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/place/FinalVoteActivity.kt
@@ -42,7 +42,10 @@ class FinalVoteActivity : AppCompatActivity() {
         setupRecyclerView()
         observeViewModel()
 
-        // Firestore에서 모든 사용자의 순위 지정 불러와서 점수 합산
+        // ⭐ vote 문서 실시간 리스너 시작 (finalCandidates 자동 업데이트)
+        viewModel.startListeningToVoteStatus(groupId)
+
+        // Firestore에서 모든 사용자의 순위 지정 불러와서 점수 합산하여 vote 문서 업데이트
         viewModel.loadAllUserRankingsAndCreateCandidates(groupId)
     }
 

--- a/app/src/main/java/com/moyeoyo/app/ui/place/FinalVoteActivity.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/place/FinalVoteActivity.kt
@@ -37,27 +37,13 @@ class FinalVoteActivity : AppCompatActivity() {
         setContentView(binding.root)
 
         val groupId = intent.getStringExtra("groupId") ?: ""
-        val rankedPlaceParcelables = intent.getParcelableArrayListExtra<RankedPlaceParcelable>("rankedPlaces") ?: arrayListOf()
 
         setupViews()
         setupRecyclerView()
         observeViewModel()
 
-        // Parcelable을 RankedPlace로 변환
-        val rankedPlaces = rankedPlaceParcelables.map { it.toRankedPlace() }
-
-        // 순위별 점수 합산하여 상위 3개 선정
-        val top3Candidates = calculateTop3Candidates(rankedPlaces)
-        
-        finalCandidates.clear()
-        finalCandidates.addAll(top3Candidates)
-        adapter.submitList(finalCandidates)
-
-        // Firestore에 후보 저장
-        viewModel.savePlaceCandidates(groupId, rankedPlaces)
-
-        // 투표 상태 확인
-        viewModel.loadVoteStatus(groupId)
+        // Firestore에서 모든 사용자의 순위 지정 불러와서 점수 합산
+        viewModel.loadAllUserRankingsAndCreateCandidates(groupId)
     }
 
     private fun setupViews() {
@@ -84,6 +70,14 @@ class FinalVoteActivity : AppCompatActivity() {
                 candidate
             }
             
+            // 클릭 시 대중교통 시간 계산 (현재 사용자 위치 기준)
+            if (selectedCandidate != null) {
+                viewModel.calculateTransitTimeForPlace(candidate.place)
+            } else {
+                // 선택 해제 시 대중교통 시간 제거
+                viewModel.calculateTransitTimeForPlace(candidate.place) // 같은 장소를 다시 클릭하면 제거됨
+            }
+            
             // 어댑터 업데이트
             finalCandidates.forEachIndexed { index, item ->
                 finalCandidates[index] = item.copy(isSelected = item == selectedCandidate)
@@ -99,20 +93,78 @@ class FinalVoteActivity : AppCompatActivity() {
     }
 
     private fun observeViewModel() {
+        viewModel.finalCandidates.observe(this) { candidates ->
+            android.util.Log.d("FinalVoteActivity", 
+                "🔍 finalCandidates observer 트리거 - 후보 수: ${candidates.size}")
+            
+            if (candidates.isEmpty()) {
+                android.util.Log.w("FinalVoteActivity", 
+                    "⚠️ 최종 후보 목록이 비어있습니다.")
+                // 빈 리스트도 어댑터에 전달 (기존 데이터 클리어)
+                finalCandidates.clear()
+                adapter.submitList(emptyList())
+                return@observe
+            }
+            
+            // 로그 출력: 각 후보 정보
+            candidates.forEachIndexed { index, candidate ->
+                android.util.Log.d("FinalVoteActivity", 
+                    "  [${index + 1}] ${candidate.place.name} - 총점: ${candidate.totalScore}점, placeId: ${candidate.place.placeId}")
+            }
+            
+            // 기존 데이터 업데이트
+            finalCandidates.clear()
+            finalCandidates.addAll(candidates)
+            
+            android.util.Log.d("FinalVoteActivity", 
+                "✅ 어댑터에 ${candidates.size}개 후보 전달 시작")
+            
+            // ⚠️ 중요: ListAdapter는 새 리스트 인스턴스를 요구하므로 toList()로 복사본 생성
+            adapter.submitList(candidates.toList()) {
+                // submitList 완료 후 콜백
+                android.util.Log.d("FinalVoteActivity", 
+                    "✅ RecyclerView 어댑터 업데이트 완료 - 아이템 수: ${adapter.itemCount}")
+                
+                // RecyclerView가 제대로 업데이트되었는지 확인
+                if (adapter.itemCount > 0) {
+                    android.util.Log.d("FinalVoteActivity", 
+                        "✅ RecyclerView에 ${adapter.itemCount}개 아이템 표시됨")
+                } else {
+                    android.util.Log.e("FinalVoteActivity", 
+                        "❌ RecyclerView 어댑터에 아이템이 없습니다!")
+                }
+            }
+        }
+
+        // 대중교통 소요시간 업데이트
+        viewModel.transitTimes.observe(this) { transitTimes ->
+            // 소요시간 업데이트 시 어댑터 데이터만 업데이트 (스크롤 위치 유지)
+            adapter.updateTransitTimes(transitTimes)
+        }
+
         viewModel.voteStatus.observe(this) { status ->
             binding.tvVoteStatus.text = "투표 상태: ${status.completed}/${status.total} 명 완료"
+            
+            // 모든 그룹원이 투표했는지 확인 (이미 loadVoteStatus에서 승리한 장소 확인 후 winningPlace LiveData 업데이트)
+            // 이 observer는 단순히 투표 상태만 표시
         }
 
         viewModel.voteSuccess.observe(this) { success ->
             if (success) {
-                Toast.makeText(this, "투표가 완료되었습니다.", Toast.LENGTH_SHORT).show()
+                android.util.Log.d("FinalVoteActivity", 
+                    "✅ 투표 완료 - 투표 상태 다시 확인 시작")
+                val groupId = intent.getStringExtra("groupId") ?: ""
+                // 투표 완료 후 상태 확인 (승리한 장소 확인을 위해)
+                viewModel.loadVoteStatus(groupId)
             }
         }
 
         viewModel.winningPlace.observe(this) { winningPlace ->
             winningPlace?.let { place ->
                 // 승리한 장소가 확인되면 팝업 표시 (중복 방지)
-                if (!isFinishing) {
+                if (!isFinishing && !isDestroyed) {
+                    android.util.Log.d("FinalVoteActivity", 
+                        "🏆 승리한 장소 확인: ${place.name}")
                     showWinningPlaceDialog(place)
                 }
             }
@@ -121,6 +173,14 @@ class FinalVoteActivity : AppCompatActivity() {
         viewModel.error.observe(this) { error ->
             error?.let {
                 Toast.makeText(this, it, Toast.LENGTH_SHORT).show()
+            }
+        }
+        
+        // 저장 완료 후 투표 상태 확인
+        viewModel.saveComplete.observe(this) { saved ->
+            if (saved) {
+                val groupId = intent.getStringExtra("groupId") ?: ""
+                viewModel.loadVoteStatus(groupId)
             }
         }
     }
@@ -147,30 +207,5 @@ class FinalVoteActivity : AppCompatActivity() {
             .show()
     }
 
-    private fun calculateTop3Candidates(rankedPlaces: List<RankedPlace>): List<FinalCandidate> {
-        // placeId별로 점수 합산
-        val scoreMap = mutableMapOf<String, Int>()
-        
-        rankedPlaces.forEach { rankedPlace ->
-            val currentScore = scoreMap[rankedPlace.place.placeId] ?: 0
-            scoreMap[rankedPlace.place.placeId] = currentScore + rankedPlace.score
-        }
-
-        // 점수 높은 순으로 정렬하여 상위 3개 선택
-        val top3 = scoreMap.entries
-            .sortedByDescending { it.value }
-            .take(3)
-
-        // FinalCandidate 리스트 생성
-        return top3.mapNotNull { (placeId, totalScore) ->
-            rankedPlaces.firstOrNull { it.place.placeId == placeId }?.let { rankedPlace ->
-                FinalCandidate(
-                    place = rankedPlace.place,
-                    totalScore = totalScore,
-                    isSelected = false
-                )
-            }
-        }
-    }
 }
 

--- a/app/src/main/java/com/moyeoyo/app/ui/place/FinalVoteActivity.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/place/FinalVoteActivity.kt
@@ -30,6 +30,9 @@ class FinalVoteActivity : AppCompatActivity() {
     private val finalCandidates = mutableListOf<FinalCandidate>()
     private var selectedCandidate: FinalCandidate? = null
     private val auth = FirebaseAuth.getInstance()
+    
+    // ⭐ 다이얼로그 메모리 누수 방지를 위한 변수
+    private var winningPlaceDialog: AlertDialog? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -155,10 +158,8 @@ class FinalVoteActivity : AppCompatActivity() {
         viewModel.voteSuccess.observe(this) { success ->
             if (success) {
                 android.util.Log.d("FinalVoteActivity", 
-                    "✅ 투표 완료 - 투표 상태 다시 확인 시작")
-                val groupId = intent.getStringExtra("groupId") ?: ""
-                // 투표 완료 후 상태 확인 (승리한 장소 확인을 위해)
-                viewModel.loadVoteStatus(groupId)
+                    "✅ 투표 완료 - 승리 장소 결정은 ViewModel에서 처리됨")
+                // ⚠️ loadVoteStatus 호출 제거 - submitVote에서 이미 처리됨
             }
         }
 
@@ -179,19 +180,30 @@ class FinalVoteActivity : AppCompatActivity() {
             }
         }
         
-        // 저장 완료 후 투표 상태 확인
+        // ⚠️ saveComplete observer에서 loadVoteStatus 호출 제거
+        // 이전 테스트의 finalVotedUsers가 남아있어서 잘못된 판단이 발생할 수 있음
+        // finalCandidates는 startListeningToVoteStatus에서 자동으로 업데이트됨
         viewModel.saveComplete.observe(this) { saved ->
             if (saved) {
-                val groupId = intent.getStringExtra("groupId") ?: ""
-                viewModel.loadVoteStatus(groupId)
+                android.util.Log.d("FinalVoteActivity", 
+                    "✅ 후보 저장 완료 - finalCandidates는 vote 문서 리스너에서 자동 업데이트됨")
             }
         }
     }
     
     private fun showWinningPlaceDialog(winningPlace: NearbyPlace) {
+        // ⭐ Activity가 종료 중이면 다이얼로그를 띄우지 않음 (메모리 누수 방지)
+        if (isFinishing || isDestroyed) {
+            return
+        }
+        
+        // ⭐ 기존 다이얼로그가 있으면 먼저 닫기
+        winningPlaceDialog?.dismiss()
+        
         val groupId = intent.getStringExtra("groupId") ?: ""
         
-        AlertDialog.Builder(this)
+        // ⭐ 다이얼로그를 변수에 저장하여 onDestroy에서 닫을 수 있도록 함
+        winningPlaceDialog = AlertDialog.Builder(this)
             .setTitle("최종 약속 장소 확정")
             .setMessage("최종 약속 장소는 \"${winningPlace.name}\"로 선정되었습니다.\n중간값 계산 화면으로 이동하여 소요시간을 확인하시겠습니까?")
             .setPositiveButton("확인") { _, _ ->
@@ -207,7 +219,16 @@ class FinalVoteActivity : AppCompatActivity() {
                 finish()
             }
             .setCancelable(false)
-            .show()
+            .create()
+        
+        winningPlaceDialog?.show()
+    }
+    
+    override fun onDestroy() {
+        super.onDestroy()
+        // ⭐ Activity가 파괴될 때 다이얼로그가 열려있다면 반드시 닫아줌 (메모리 누수 방지)
+        winningPlaceDialog?.dismiss()
+        winningPlaceDialog = null
     }
 
 }

--- a/app/src/main/java/com/moyeoyo/app/ui/place/FinalVoteViewModel.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/place/FinalVoteViewModel.kt
@@ -5,12 +5,16 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.auth.FirebaseAuth
+import android.location.Location
+import com.moyeoyo.app.data.model.InputLocation
 import com.moyeoyo.app.data.model.LatLngData
 import com.moyeoyo.app.data.model.NearbyPlace
 import com.moyeoyo.app.data.model.PlaceCandidate
 import com.moyeoyo.app.data.model.RankedPlace
+import com.moyeoyo.app.data.model.TransportMode
 import com.moyeoyo.app.data.repository.GroupRepository
 import com.moyeoyo.app.data.repository.MapRepository
+import com.moyeoyo.app.ui.place.FinalCandidate
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -41,12 +45,29 @@ class FinalVoteViewModel @Inject constructor(
     private val _error = MutableLiveData<String?>(null)
     val error: LiveData<String?> = _error
 
+    private val _saveComplete = MutableLiveData<Boolean>(false)
+    val saveComplete: LiveData<Boolean> = _saveComplete
+
+    private val _finalCandidates = MutableLiveData<List<FinalCandidate>>(emptyList())
+    val finalCandidates: LiveData<List<FinalCandidate>> = _finalCandidates
+
+    // placeId -> 대중교통 소요시간 (초) - 한 번에 하나만 표시
+    private val _transitTimes = MutableLiveData<Map<String, Int>>(emptyMap())
+    val transitTimes: LiveData<Map<String, Int>> = _transitTimes
+    
+    private var userInputLocation: InputLocation? = null
+    private var currentSelectedPlaceId: String? = null
+
     /**
      * 순위별 점수 합산하여 상위 3개 후보를 Firestore에 저장
      */
     fun savePlaceCandidates(groupId: String, rankedPlaces: List<RankedPlace>) {
+        _saveComplete.value = false
         viewModelScope.launch {
             try {
+                // 기존 후보 모두 삭제 (이전 세션 데이터 정리) - 완료될 때까지 대기
+                mapRepository.clearPlaceCandidates(groupId)
+                
                 // placeId별로 점수 합산
                 val scoreMap = mutableMapOf<String, Int>()
                 rankedPlaces.forEach { rankedPlace ->
@@ -66,8 +87,12 @@ class FinalVoteViewModel @Inject constructor(
                         mapRepository.addPlaceCandidate(groupId, candidate)
                     }
                 }
+                
+                // 저장 완료 신호
+                _saveComplete.value = true
             } catch (e: Exception) {
                 _error.value = "후보 저장에 실패했습니다: ${e.message}"
+                _saveComplete.value = false
             }
         }
     }
@@ -129,6 +154,175 @@ class FinalVoteViewModel @Inject constructor(
                 _error.value = "투표 상태를 불러오는데 실패했습니다: ${e.message}"
             }
         }
+    }
+
+    /**
+     * 모든 사용자의 순위 지정 불러와서 점수 합산하여 상위 3개 후보 생성 및 저장
+     */
+    fun loadAllUserRankingsAndCreateCandidates(groupId: String) {
+        viewModelScope.launch {
+            try {
+                android.util.Log.d("FinalVoteViewModel", 
+                    "📥 모든 사용자 순위 불러오기 시작 - groupId: $groupId")
+                
+                // 현재 사용자의 입력 위치 가져오기 (거리 및 대중교통 시간 계산용)
+                val inputLocations = mapRepository.getInputLocations(groupId)
+                val currentUserId = mapRepository.currentUserId()
+                userInputLocation = inputLocations.find { it.uid == currentUserId }
+                
+                android.util.Log.d("FinalVoteViewModel", 
+                    "📍 현재 사용자 입력 위치: ${if (userInputLocation != null) "있음" else "없음"}")
+                
+                // Firestore에서 모든 사용자의 순위 지정 불러오기 (서버에서 직접 가져오기)
+                val allUserRankings = mapRepository.getAllUserRankings(groupId)
+                
+                android.util.Log.d("FinalVoteViewModel", 
+                    "📥 모든 사용자 순위 불러오기 완료 - 사용자 수: ${allUserRankings.size}")
+                
+                // 모든 사용자의 RankedPlace 리스트로 변환
+                val allRankedPlaces = allUserRankings.values.flatten()
+                
+                android.util.Log.d("FinalVoteViewModel", 
+                    "📊 총 RankedPlace 수: ${allRankedPlaces.size}")
+                
+                if (allRankedPlaces.isEmpty()) {
+                    android.util.Log.e("FinalVoteViewModel", 
+                        "❌ 순위 지정 데이터가 비어있습니다 - allUserRankings: $allUserRankings")
+                    _error.value = "순위 지정 데이터를 불러올 수 없습니다. 모든 사용자가 순위를 확정했는지 확인해주세요."
+                    return@launch
+                }
+                
+                // placeId별로 점수 합산
+                val scoreMap = mutableMapOf<String, Int>()
+                allRankedPlaces.forEach { rankedPlace ->
+                    val currentScore = scoreMap[rankedPlace.place.placeId] ?: 0
+                    scoreMap[rankedPlace.place.placeId] = currentScore + rankedPlace.score
+                }
+                
+                android.util.Log.d("FinalVoteViewModel", 
+                    "📊 점수 집계 완료 - 장소 수: ${scoreMap.size}")
+                
+                // 점수 높은 순으로 정렬하여 상위 3개 선택
+                val top3 = scoreMap.entries
+                    .sortedByDescending { it.value }
+                    .take(3)
+                
+                android.util.Log.d("FinalVoteViewModel", 
+                    "🏆 상위 3개 선택 완료 - 장소 수: ${top3.size}")
+                
+                // FinalCandidate 리스트 생성 (거리 정보만 현재 사용자 기준으로 재계산)
+                val candidates = top3.mapNotNull { (placeId, totalScore) ->
+                    allRankedPlaces.firstOrNull { it.place.placeId == placeId }?.let { rankedPlace ->
+                        // 현재 사용자의 입력 위치를 기준으로 거리만 재계산 (평점, 카테고리는 저장된 데이터 사용)
+                        val updatedPlace = userInputLocation?.let { inputLoc ->
+                            val distanceMeters = calculateDistanceMeters(
+                                inputLoc.latLng,
+                                rankedPlace.place.latLng
+                            )
+                            rankedPlace.place.copy(distanceMeters = distanceMeters)
+                        } ?: rankedPlace.place
+                        
+                        android.util.Log.d("FinalVoteViewModel", 
+                            "✅ 후보 생성 - placeId: $placeId, 이름: ${updatedPlace.name}, 총점: $totalScore, 평점: ${updatedPlace.rating}, 거리: ${updatedPlace.distanceMeters}m")
+                        FinalCandidate(
+                            place = updatedPlace,
+                            totalScore = totalScore,
+                            isSelected = false
+                        )
+                    }
+                }
+                
+                android.util.Log.d("FinalVoteViewModel", 
+                    "✅ FinalCandidate 리스트 생성 완료 - 후보 수: ${candidates.size}")
+                
+                if (candidates.isEmpty()) {
+                    android.util.Log.e("FinalVoteViewModel", 
+                        "❌ FinalCandidate 리스트가 비어있습니다")
+                    _error.value = "최종 후보를 생성할 수 없습니다."
+                    return@launch
+                }
+                
+                // ⚠️ 중요: LiveData 업데이트는 메인 스레드에서 수행
+                // 코루틴이 다른 디스패처에서 실행될 수 있으므로 Main으로 전환
+                kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Main) {
+                    android.util.Log.d("FinalVoteViewModel", 
+                        "📤 _finalCandidates LiveData 업데이트 중 - 후보 수: ${candidates.size}")
+                    _finalCandidates.value = candidates
+                    android.util.Log.d("FinalVoteViewModel", 
+                        "✅ _finalCandidates LiveData 업데이트 완료")
+                }
+                
+                // 상위 3개 후보를 RankedPlace로 변환하여 Firestore에 저장
+                val top3RankedPlaces = top3.mapNotNull { (placeId, totalScore) ->
+                    allRankedPlaces.firstOrNull { it.place.placeId == placeId }
+                }
+                
+                android.util.Log.d("FinalVoteViewModel", 
+                    "💾 Firestore에 후보 저장 시작 - 후보 수: ${top3RankedPlaces.size}")
+                
+                // Firestore에 후보 저장 (완료 후 투표 상태 확인)
+                savePlaceCandidates(groupId, top3RankedPlaces)
+                
+            } catch (e: Exception) {
+                android.util.Log.e("FinalVoteViewModel", 
+                    "❌ 순위 데이터를 불러오는데 실패했습니다: ${e.message}", e)
+                _error.value = "순위 데이터를 불러오는데 실패했습니다: ${e.message}"
+            }
+        }
+    }
+
+    /**
+     * 특정 장소에 대한 대중교통 소요시간 계산
+     */
+    fun calculateTransitTimeForPlace(place: NearbyPlace) {
+        val inputLocation = userInputLocation ?: return
+        
+        // 같은 장소를 다시 클릭하면 제거
+        if (currentSelectedPlaceId == place.placeId) {
+            currentSelectedPlaceId = null
+            _transitTimes.value = emptyMap()
+            return
+        }
+        
+        // 새로운 장소 선택
+        currentSelectedPlaceId = place.placeId
+        
+        viewModelScope.launch {
+            try {
+                val userInput = InputLocation(
+                    uid = inputLocation.uid,
+                    latLng = inputLocation.latLng,
+                    transportMode = TransportMode.TRANSIT
+                )
+
+                val results = mapRepository.fetchDistanceMatrix(
+                    origins = listOf(userInput),
+                    destination = place.latLng
+                )
+
+                results.firstOrNull()?.let { result ->
+                    // 선택된 장소만 표시 (기존 것 제거)
+                    _transitTimes.value = mapOf(place.placeId to result.durationSeconds)
+                    android.util.Log.d("FinalVoteViewModel", 
+                        "✅ 대중교통 시간 계산 완료 - 장소: ${place.name}, 시간: ${result.durationSeconds}초")
+                }
+            } catch (e: Exception) {
+                android.util.Log.e("FinalVoteViewModel", 
+                    "❌ 대중교통 시간 계산 실패: ${e.message}", e)
+                // 소요시간 계산 실패는 무시
+                currentSelectedPlaceId = null
+                _transitTimes.value = emptyMap()
+            }
+        }
+    }
+
+    /**
+     * 두 좌표 사이의 거리 계산 (미터 단위)
+     */
+    private fun calculateDistanceMeters(from: LatLngData, to: LatLngData): Double {
+        val result = FloatArray(1)
+        Location.distanceBetween(from.lat, from.lng, to.lat, to.lng, result)
+        return result.firstOrNull()?.toDouble() ?: 0.0
     }
 
     /**

--- a/app/src/main/java/com/moyeoyo/app/ui/place/FinalVoteViewModel.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/place/FinalVoteViewModel.kt
@@ -6,16 +6,21 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.auth.FirebaseAuth
 import android.location.Location
+import com.google.firebase.firestore.GeoPoint
+import com.moyeoyo.app.data.model.FinalCandidateData
 import com.moyeoyo.app.data.model.InputLocation
 import com.moyeoyo.app.data.model.LatLngData
 import com.moyeoyo.app.data.model.NearbyPlace
 import com.moyeoyo.app.data.model.PlaceCandidate
 import com.moyeoyo.app.data.model.RankedPlace
 import com.moyeoyo.app.data.model.TransportMode
+import com.moyeoyo.app.data.model.Vote
 import com.moyeoyo.app.data.repository.GroupRepository
 import com.moyeoyo.app.data.repository.MapRepository
 import com.moyeoyo.app.ui.place.FinalCandidate
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -99,23 +104,30 @@ class FinalVoteViewModel @Inject constructor(
 
     /**
      * 투표 상태 확인 및 승리한 장소 확인
+     * ⭐ 새로운 구조: vote 문서의 finalVotedUsers 배열을 확인하여 정확한 상태 판단
      */
     fun loadVoteStatus(groupId: String) {
         viewModelScope.launch {
             try {
-                val candidates = mapRepository.getPlaceCandidates(groupId)
                 val group = groupRepository.getGroupById(groupId)
-                
-                // 그룹 멤버 수 확인
                 val totalMembers = group?.memberUids?.size ?: 0
                 
-                // 각 후보의 투표 수 계산
-                val completedVotes = candidates.sumOf { it.voterUids.size }
+                // ⭐ vote 문서의 finalVotedUsers 배열 확인 (Single Source of Truth)
+                val allFinalVoted = groupRepository.checkAllUsersFinalVoted(groupId)
                 
+                // UI 표시용 투표 상태 (placeCandidates에서 집계)
+                val candidates = mapRepository.getPlaceCandidates(groupId)
+                val completedVotes = candidates.sumOf { it.voterUids.size }
                 _voteStatus.value = VoteStatus(completedVotes, totalMembers)
                 
-                // 모든 멤버가 투표했고, 후보가 있으면 승리한 장소 확인
-                if (totalMembers > 0 && completedVotes >= totalMembers && candidates.isNotEmpty()) {
+                android.util.Log.d("FinalVoteViewModel", 
+                    "🔍 투표 상태 확인 - groupId: $groupId, totalMembers: $totalMembers, completedVotes: $completedVotes, allFinalVoted: $allFinalVoted")
+                
+                // 모든 멤버가 최종 투표를 완료했고, 후보가 있으면 승리한 장소 확인
+                if (allFinalVoted && candidates.isNotEmpty()) {
+                    android.util.Log.d("FinalVoteViewModel", 
+                        "🏆 모든 사용자 최종 투표 완료! 승리한 장소 결정 시작")
+                    
                     // 각 후보의 최종 투표 수 계산
                     val voteCounts = candidates.map { it to it.voterUids.size }
                     val maxVotes = voteCounts.maxOfOrNull { it.second } ?: 0
@@ -132,7 +144,13 @@ class FinalVoteViewModel @Inject constructor(
                     }
                     
                     winningCandidate?.let { candidate ->
-                        // PlaceCandidate를 NearbyPlace로 변환
+                        // ⭐ vote 문서에 승리한 장소 저장 및 상태를 FINISHED로 변경
+                        groupRepository.setWinningPlace(groupId, candidate.placeId, candidate.name)
+                        
+                        android.util.Log.d("FinalVoteViewModel", 
+                            "✅ 승리한 장소 결정: ${candidate.name} (placeId: ${candidate.placeId})")
+                        
+                        // PlaceCandidate를 NearbyPlace로 변환하여 UI에 표시
                         val latLng = candidate.latLng?.let { 
                             LatLngData(it.latitude, it.longitude) 
                         } ?: LatLngData(0.0, 0.0)
@@ -149,15 +167,104 @@ class FinalVoteViewModel @Inject constructor(
                         
                         _winningPlace.value = winningPlace
                     }
+                } else {
+                    android.util.Log.d("FinalVoteViewModel", 
+                        "⏸️ 아직 모든 사용자가 최종 투표를 완료하지 않음 - completedVotes: $completedVotes, totalMembers: $totalMembers")
                 }
             } catch (e: Exception) {
+                android.util.Log.e("FinalVoteViewModel", 
+                    "❌ 투표 상태 확인 실패: ${e.message}", e)
                 _error.value = "투표 상태를 불러오는데 실패했습니다: ${e.message}"
             }
         }
     }
 
     /**
+     * vote 문서 실시간 리스너 시작
+     * ⭐ 새로운 구조: vote 문서를 관찰하여 finalCandidates를 가져오고 상태 변경 감지
+     */
+    fun startListeningToVoteStatus(groupId: String) {
+        viewModelScope.launch {
+            // 현재 사용자의 입력 위치 가져오기 (거리 계산용)
+            val inputLocations = mapRepository.getInputLocations(groupId)
+            val currentUserId = mapRepository.currentUserId()
+            userInputLocation = inputLocations.find { it.uid == currentUserId }
+            
+            android.util.Log.d("FinalVoteViewModel", 
+                "📍 현재 사용자 입력 위치: ${if (userInputLocation != null) "있음" else "없음"}")
+            
+            // vote 문서 실시간 리스너 시작
+            groupRepository.listenToVoteStatus(groupId)
+                .onEach { vote ->
+                    if (vote != null) {
+                        android.util.Log.d("FinalVoteViewModel", 
+                            "🔍 vote 문서 업데이트 - status: ${vote.status}, finalCandidates: ${vote.finalCandidates.size}개")
+                        
+                        when (vote.status) {
+                            "FINAL_VOTING" -> {
+                                // finalCandidates를 FinalCandidate로 변환
+                                val candidates = vote.finalCandidates.map { candidateData ->
+                                    val nearbyPlace = NearbyPlace(
+                                        placeId = candidateData.placeId,
+                                        name = candidateData.name,
+                                        address = candidateData.address,
+                                        latLng = LatLngData(
+                                            candidateData.latLng.latitude,
+                                            candidateData.latLng.longitude
+                                        ),
+                                        categories = candidateData.categories,
+                                        rating = candidateData.rating,
+                                        distanceMeters = userInputLocation?.let { inputLoc ->
+                                            calculateDistanceMeters(
+                                                inputLoc.latLng,
+                                                LatLngData(
+                                                    candidateData.latLng.latitude,
+                                                    candidateData.latLng.longitude
+                                                )
+                                            )
+                                        } ?: 0.0
+                                    )
+                                    
+                                    FinalCandidate(
+                                        place = nearbyPlace,
+                                        totalScore = candidateData.totalScore,
+                                        isSelected = false
+                                    )
+                                }
+                                
+                                android.util.Log.d("FinalVoteViewModel", 
+                                    "✅ finalCandidates 변환 완료 - 후보 수: ${candidates.size}")
+                                
+                                _finalCandidates.value = candidates
+                            }
+                            "FINISHED" -> {
+                                // 투표 완료 상태 - 승리한 장소 표시
+                                vote.winningPlaceId?.let { placeId ->
+                                    vote.winningPlaceName?.let { placeName ->
+                                        // 승리한 장소로 NearbyPlace 생성 (정확한 정보는 vote 문서에서 가져올 수 있음)
+                                        val winningPlace = NearbyPlace(
+                                            placeId = placeId,
+                                            name = placeName,
+                                            address = null,
+                                            latLng = LatLngData(0.0, 0.0), // 필요시 vote 문서에 좌표 추가 가능
+                                            categories = emptyList(),
+                                            rating = null,
+                                            distanceMeters = 0.0
+                                        )
+                                        _winningPlace.value = winningPlace
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                .launchIn(viewModelScope)
+        }
+    }
+
+    /**
      * 모든 사용자의 순위 지정 불러와서 점수 합산하여 상위 3개 후보 생성 및 저장
+     * ⭐ 새로운 구조: vote 문서의 finalCandidates 업데이트 후, vote 문서 리스너가 자동으로 UI 업데이트
      */
     fun loadAllUserRankingsAndCreateCandidates(groupId: String) {
         viewModelScope.launch {
@@ -165,13 +272,10 @@ class FinalVoteViewModel @Inject constructor(
                 android.util.Log.d("FinalVoteViewModel", 
                     "📥 모든 사용자 순위 불러오기 시작 - groupId: $groupId")
                 
-                // 현재 사용자의 입력 위치 가져오기 (거리 및 대중교통 시간 계산용)
+                // 현재 사용자의 입력 위치 가져오기 (거리 계산용)
                 val inputLocations = mapRepository.getInputLocations(groupId)
                 val currentUserId = mapRepository.currentUserId()
                 userInputLocation = inputLocations.find { it.uid == currentUserId }
-                
-                android.util.Log.d("FinalVoteViewModel", 
-                    "📍 현재 사용자 입력 위치: ${if (userInputLocation != null) "있음" else "없음"}")
                 
                 // Firestore에서 모든 사용자의 순위 지정 불러오기 (서버에서 직접 가져오기)
                 val allUserRankings = mapRepository.getAllUserRankings(groupId)
@@ -187,7 +291,7 @@ class FinalVoteViewModel @Inject constructor(
                 
                 if (allRankedPlaces.isEmpty()) {
                     android.util.Log.e("FinalVoteViewModel", 
-                        "❌ 순위 지정 데이터가 비어있습니다 - allUserRankings: $allUserRankings")
+                        "❌ 순위 지정 데이터가 비어있습니다")
                     _error.value = "순위 지정 데이터를 불러올 수 없습니다. 모든 사용자가 순위를 확정했는지 확인해주세요."
                     return@launch
                 }
@@ -210,55 +314,51 @@ class FinalVoteViewModel @Inject constructor(
                 android.util.Log.d("FinalVoteViewModel", 
                     "🏆 상위 3개 선택 완료 - 장소 수: ${top3.size}")
                 
-                // FinalCandidate 리스트 생성 (거리 정보만 현재 사용자 기준으로 재계산)
-                val candidates = top3.mapNotNull { (placeId, totalScore) ->
+                // FinalCandidateData 리스트 생성 (vote 문서에 저장할 데이터)
+                val finalCandidateDataList = top3.mapNotNull { (placeId, totalScore) ->
                     allRankedPlaces.firstOrNull { it.place.placeId == placeId }?.let { rankedPlace ->
-                        // 현재 사용자의 입력 위치를 기준으로 거리만 재계산 (평점, 카테고리는 저장된 데이터 사용)
-                        val updatedPlace = userInputLocation?.let { inputLoc ->
-                            val distanceMeters = calculateDistanceMeters(
-                                inputLoc.latLng,
-                                rankedPlace.place.latLng
-                            )
-                            rankedPlace.place.copy(distanceMeters = distanceMeters)
-                        } ?: rankedPlace.place
-                        
-                        android.util.Log.d("FinalVoteViewModel", 
-                            "✅ 후보 생성 - placeId: $placeId, 이름: ${updatedPlace.name}, 총점: $totalScore, 평점: ${updatedPlace.rating}, 거리: ${updatedPlace.distanceMeters}m")
-                        FinalCandidate(
-                            place = updatedPlace,
+                        FinalCandidateData(
+                            placeId = rankedPlace.place.placeId,
+                            name = rankedPlace.place.name,
+                            latLng = GeoPoint(
+                                rankedPlace.place.latLng.lat,
+                                rankedPlace.place.latLng.lng
+                            ),
                             totalScore = totalScore,
-                            isSelected = false
+                            categories = rankedPlace.place.categories,
+                            rating = rankedPlace.place.rating,
+                            address = rankedPlace.place.address
                         )
                     }
                 }
                 
                 android.util.Log.d("FinalVoteViewModel", 
-                    "✅ FinalCandidate 리스트 생성 완료 - 후보 수: ${candidates.size}")
+                    "✅ FinalCandidateData 리스트 생성 완료 - 후보 수: ${finalCandidateDataList.size}")
                 
-                if (candidates.isEmpty()) {
+                if (finalCandidateDataList.isEmpty()) {
                     android.util.Log.e("FinalVoteViewModel", 
-                        "❌ FinalCandidate 리스트가 비어있습니다")
+                        "❌ FinalCandidateData 리스트가 비어있습니다")
                     _error.value = "최종 후보를 생성할 수 없습니다."
                     return@launch
                 }
                 
-                // ⚠️ 중요: LiveData 업데이트는 메인 스레드에서 수행
-                // 코루틴이 다른 디스패처에서 실행될 수 있으므로 Main으로 전환
-                kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Main) {
-                    android.util.Log.d("FinalVoteViewModel", 
-                        "📤 _finalCandidates LiveData 업데이트 중 - 후보 수: ${candidates.size}")
-                    _finalCandidates.value = candidates
-                    android.util.Log.d("FinalVoteViewModel", 
-                        "✅ _finalCandidates LiveData 업데이트 완료")
-                }
+                // ⭐ vote 문서의 finalCandidates 업데이트 및 상태를 FINAL_VOTING으로 변경
+                android.util.Log.d("FinalVoteViewModel", 
+                    "💾 vote 문서에 finalCandidates 업데이트 및 상태 변경 시작 - 후보 수: ${finalCandidateDataList.size}")
                 
-                // 상위 3개 후보를 RankedPlace로 변환하여 Firestore에 저장
+                groupRepository.updateFinalCandidates(groupId, finalCandidateDataList)
+                
+                android.util.Log.d("FinalVoteViewModel", 
+                    "✅ vote 문서 업데이트 완료 - status: FINAL_VOTING")
+                
+                // 상위 3개 후보를 RankedPlace로 변환하여 Firestore에 저장 (placeCandidates 컬렉션)
+                // ⚠️ 참고: 이건 기존 로직 유지 (finalVote에서 투표 수 집계용)
                 val top3RankedPlaces = top3.mapNotNull { (placeId, totalScore) ->
                     allRankedPlaces.firstOrNull { it.place.placeId == placeId }
                 }
                 
                 android.util.Log.d("FinalVoteViewModel", 
-                    "💾 Firestore에 후보 저장 시작 - 후보 수: ${top3RankedPlaces.size}")
+                    "💾 placeCandidates 컬렉션에 후보 저장 시작 - 후보 수: ${top3RankedPlaces.size}")
                 
                 // Firestore에 후보 저장 (완료 후 투표 상태 확인)
                 savePlaceCandidates(groupId, top3RankedPlaces)
@@ -338,7 +438,14 @@ class FinalVoteViewModel @Inject constructor(
                 val candidate = candidates.firstOrNull { it.placeId == placeId }
                 
                 if (candidate != null) {
+                    // 1. placeCandidates 컬렉션에 투표 기록 (기존 로직 유지)
                     mapRepository.votePlaceCandidate(groupId, candidate.id, uid)
+                    
+                    // 2. ⭐ vote 문서의 finalVotedUsers 배열에 현재 사용자 추가 (새로운 구조)
+                    groupRepository.addUserToFinalVotedList(groupId, uid)
+                    
+                    android.util.Log.d("FinalVoteViewModel", 
+                        "✅ 최종 투표 완료 - placeId: $placeId, uid: $uid")
                     
                     // 투표 후 상태 다시 확인 (승리한 장소 확인을 위해)
                     loadVoteStatus(groupId)
@@ -348,6 +455,8 @@ class FinalVoteViewModel @Inject constructor(
                     _error.value = "후보를 찾을 수 없습니다."
                 }
             } catch (e: Exception) {
+                android.util.Log.e("FinalVoteViewModel", 
+                    "❌ 최종 투표 실패: ${e.message}", e)
                 _error.value = "투표에 실패했습니다: ${e.message}"
             }
         }

--- a/app/src/main/java/com/moyeoyo/app/ui/place/FinalVoteViewModel.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/place/FinalVoteViewModel.kt
@@ -181,6 +181,12 @@ class FinalVoteViewModel @Inject constructor(
                 android.util.Log.d("FinalVoteViewModel", 
                     "✅ 승리한 장소 결정: ${candidate.name} (placeId: ${candidate.placeId})")
                 
+                // ⭐ vote 문서의 finalCandidates에서 승리한 장소의 상세 정보 가져오기 (주소 포함)
+                val voteStatus = groupRepository.getVoteStatus(groupId)
+                val finalCandidate = voteStatus?.finalCandidates?.firstOrNull { 
+                    it.placeId == candidate.placeId 
+                }
+                
                 // PlaceCandidate를 NearbyPlace로 변환하여 UI에 표시
                         val latLng = candidate.latLng?.let { 
                             LatLngData(it.latitude, it.longitude) 
@@ -189,10 +195,10 @@ class FinalVoteViewModel @Inject constructor(
                         val winningPlace = NearbyPlace(
                             placeId = candidate.placeId,
                             name = candidate.name,
-                            address = null,
+                            address = finalCandidate?.address, // ⭐ finalCandidates에서 주소 가져오기
                             latLng = latLng,
-                            categories = emptyList(),
-                            rating = null,
+                            categories = finalCandidate?.categories ?: emptyList(),
+                            rating = finalCandidate?.rating,
                     distanceMeters = userInputLocation?.let { inputLoc ->
                         calculateDistanceMeters(
                             inputLoc.latLng,
@@ -503,13 +509,11 @@ class FinalVoteViewModel @Inject constructor(
                     loadVoteStatus(groupId)
                     
                     // 4. ⭐ 내 투표 완료 후 충분한 지연을 두고 모든 사용자 완료 여부 확인 (Firestore 서버 동기화 시간 확보)
-                    kotlinx.coroutines.delay(1500)
-                    
-                    // 5. ⭐ 핵심: 내 투표 후에만 모든 사용자가 투표했는지 확인하고 승리 장소 결정
-                    // ⚠️ Firestore 동기화를 위한 지연 시간 필요 (다른 사용자의 투표가 반영되기 전)
                     android.util.Log.d("FinalVoteViewModel", 
                         "🔍 내 투표 저장 완료 후 모든 사용자 투표 완료 여부 확인 시작 (동기화 대기)")
                     kotlinx.coroutines.delay(1500) // Firestore 동기화 시간 확보
+                    
+                    // 5. ⭐ 핵심: 내 투표 후에만 모든 사용자가 투표했는지 확인하고 승리 장소 결정
                     determineWinner(groupId)
                     
                     _voteSuccess.value = true

--- a/app/src/main/java/com/moyeoyo/app/ui/place/FinalVoteViewModel.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/place/FinalVoteViewModel.kt
@@ -103,8 +103,8 @@ class FinalVoteViewModel @Inject constructor(
     }
 
     /**
-     * 투표 상태 확인 및 승리한 장소 확인
-     * ⭐ 새로운 구조: vote 문서의 finalVotedUsers 배열을 확인하여 정확한 상태 판단
+     * 투표 상태 확인 (UI 표시용)
+     * ⚠️ 승리한 장소 결정은 submitVote에서 처리하므로 여기서는 상태만 업데이트
      */
     fun loadVoteStatus(groupId: String) {
         viewModelScope.launch {
@@ -112,22 +112,53 @@ class FinalVoteViewModel @Inject constructor(
                 val group = groupRepository.getGroupById(groupId)
                 val totalMembers = group?.memberUids?.size ?: 0
                 
-                // ⭐ vote 문서의 finalVotedUsers 배열 확인 (Single Source of Truth)
-                val allFinalVoted = groupRepository.checkAllUsersFinalVoted(groupId)
-                
                 // UI 표시용 투표 상태 (placeCandidates에서 집계)
                 val candidates = mapRepository.getPlaceCandidates(groupId)
                 val completedVotes = candidates.sumOf { it.voterUids.size }
                 _voteStatus.value = VoteStatus(completedVotes, totalMembers)
                 
                 android.util.Log.d("FinalVoteViewModel", 
-                    "🔍 투표 상태 확인 - groupId: $groupId, totalMembers: $totalMembers, completedVotes: $completedVotes, allFinalVoted: $allFinalVoted")
-                
-                // 모든 멤버가 최종 투표를 완료했고, 후보가 있으면 승리한 장소 확인
-                if (allFinalVoted && candidates.isNotEmpty()) {
-                    android.util.Log.d("FinalVoteViewModel", 
-                        "🏆 모든 사용자 최종 투표 완료! 승리한 장소 결정 시작")
-                    
+                    "🔍 투표 상태 확인 (UI 업데이트) - groupId: $groupId, totalMembers: $totalMembers, completedVotes: $completedVotes")
+            } catch (e: Exception) {
+                android.util.Log.e("FinalVoteViewModel", 
+                    "❌ 투표 상태 확인 실패: ${e.message}", e)
+                _error.value = "투표 상태를 불러오는데 실패했습니다: ${e.message}"
+            }
+        }
+    }
+    
+    /**
+     * 승리한 장소 결정 (내 투표 후에만 호출)
+     * ⭐ 핵심: 내가 투표한 후에만 이 함수를 호출하여 승리한 장소를 결정
+     */
+    private suspend fun determineWinner(groupId: String) {
+        try {
+            val group = groupRepository.getGroupById(groupId)
+            val totalMembers = group?.memberUids?.size ?: 0
+            
+            // ⭐ vote 문서의 finalVotedUsers 배열 확인 (Single Source of Truth)
+            val allFinalVoted = groupRepository.checkAllUsersFinalVoted(groupId)
+            
+            android.util.Log.d("FinalVoteViewModel", 
+                "🔍 승리 장소 결정 확인 - groupId: $groupId, totalMembers: $totalMembers, allFinalVoted: $allFinalVoted")
+            
+            // 모든 멤버가 최종 투표를 완료했고, 후보가 있으면 승리한 장소 확인
+            if (!allFinalVoted) {
+                android.util.Log.d("FinalVoteViewModel", 
+                    "⏸️ 아직 모든 사용자가 최종 투표를 완료하지 않음 - 승리 장소 결정 대기")
+                return
+            }
+            
+            val candidates = mapRepository.getPlaceCandidates(groupId)
+            if (candidates.isEmpty()) {
+                android.util.Log.e("FinalVoteViewModel", 
+                    "❌ 후보 목록이 비어있습니다.")
+                return
+            }
+            
+            android.util.Log.d("FinalVoteViewModel", 
+                "🏆 모든 사용자 최종 투표 완료! 승리한 장소 결정 시작")
+            
                     // 각 후보의 최종 투표 수 계산
                     val voteCounts = candidates.map { it to it.voterUids.size }
                     val maxVotes = voteCounts.maxOfOrNull { it.second } ?: 0
@@ -144,13 +175,13 @@ class FinalVoteViewModel @Inject constructor(
                     }
                     
                     winningCandidate?.let { candidate ->
-                        // ⭐ vote 문서에 승리한 장소 저장 및 상태를 FINISHED로 변경
-                        groupRepository.setWinningPlace(groupId, candidate.placeId, candidate.name)
-                        
-                        android.util.Log.d("FinalVoteViewModel", 
-                            "✅ 승리한 장소 결정: ${candidate.name} (placeId: ${candidate.placeId})")
-                        
-                        // PlaceCandidate를 NearbyPlace로 변환하여 UI에 표시
+                // ⭐ vote 문서에 승리한 장소 저장 및 상태를 FINISHED로 변경
+                groupRepository.setWinningPlace(groupId, candidate.placeId, candidate.name)
+                
+                android.util.Log.d("FinalVoteViewModel", 
+                    "✅ 승리한 장소 결정: ${candidate.name} (placeId: ${candidate.placeId})")
+                
+                // PlaceCandidate를 NearbyPlace로 변환하여 UI에 표시
                         val latLng = candidate.latLng?.let { 
                             LatLngData(it.latitude, it.longitude) 
                         } ?: LatLngData(0.0, 0.0)
@@ -162,20 +193,21 @@ class FinalVoteViewModel @Inject constructor(
                             latLng = latLng,
                             categories = emptyList(),
                             rating = null,
-                            distanceMeters = 0.0
+                    distanceMeters = userInputLocation?.let { inputLoc ->
+                        calculateDistanceMeters(
+                            inputLoc.latLng,
+                            latLng
                         )
-                        
-                        _winningPlace.value = winningPlace
-                    }
-                } else {
-                    android.util.Log.d("FinalVoteViewModel", 
-                        "⏸️ 아직 모든 사용자가 최종 투표를 완료하지 않음 - completedVotes: $completedVotes, totalMembers: $totalMembers")
-                }
-            } catch (e: Exception) {
-                android.util.Log.e("FinalVoteViewModel", 
-                    "❌ 투표 상태 확인 실패: ${e.message}", e)
-                _error.value = "투표 상태를 불러오는데 실패했습니다: ${e.message}"
+                    } ?: 0.0
+                )
+                
+                _winningPlace.value = winningPlace
+                // ⚠️ 대중교통 시간 계산은 MidpointActivity에서 자동으로 처리됨 (selectNearbyPlace 호출 시)
             }
+        } catch (e: Exception) {
+            android.util.Log.e("FinalVoteViewModel", 
+                "❌ 승리 장소 결정 실패: ${e.message}", e)
+            _error.value = "승리 장소를 결정하는데 실패했습니다: ${e.message}"
         }
     }
 
@@ -241,17 +273,36 @@ class FinalVoteViewModel @Inject constructor(
                                 // 투표 완료 상태 - 승리한 장소 표시
                                 vote.winningPlaceId?.let { placeId ->
                                     vote.winningPlaceName?.let { placeName ->
-                                        // 승리한 장소로 NearbyPlace 생성 (정확한 정보는 vote 문서에서 가져올 수 있음)
+                                        // ⭐ finalCandidates에서 승리 장소를 찾아서 좌표 정보 가져오기
+                                        val winningCandidateData = vote.finalCandidates.firstOrNull { 
+                                            it.placeId == placeId 
+                                        }
+                                        
+                                        val latLng = winningCandidateData?.latLng?.let {
+                                            LatLngData(it.latitude, it.longitude)
+                                        } ?: LatLngData(0.0, 0.0)
+                                        
                                         val winningPlace = NearbyPlace(
                                             placeId = placeId,
                                             name = placeName,
-                                            address = null,
-                                            latLng = LatLngData(0.0, 0.0), // 필요시 vote 문서에 좌표 추가 가능
-                                            categories = emptyList(),
-                                            rating = null,
-                                            distanceMeters = 0.0
-                                        )
-                                        _winningPlace.value = winningPlace
+                                            address = winningCandidateData?.address,
+                                            latLng = latLng,
+                                            categories = winningCandidateData?.categories ?: emptyList(),
+                                            rating = winningCandidateData?.rating,
+                                            distanceMeters = userInputLocation?.let { inputLoc ->
+                                                if (latLng.lat != 0.0 && latLng.lng != 0.0) {
+                                                    calculateDistanceMeters(
+                                                        inputLoc.latLng,
+                                                        latLng
+                                                    )
+                                                } else {
+                                                    0.0
+                                                }
+                                            } ?: 0.0
+                        )
+                        
+                        _winningPlace.value = winningPlace
+                        // ⚠️ 대중교통 시간 계산은 MidpointActivity에서 자동으로 처리됨 (selectNearbyPlace 호출 시)
                                     }
                                 }
                             }
@@ -415,7 +466,7 @@ class FinalVoteViewModel @Inject constructor(
             }
         }
     }
-
+    
     /**
      * 두 좌표 사이의 거리 계산 (미터 단위)
      */
@@ -427,6 +478,7 @@ class FinalVoteViewModel @Inject constructor(
 
     /**
      * 최종 투표 제출
+     * ⭐ 핵심: 내 투표 후에만 모든 사용자 완료 여부를 확인하고 승리 장소 결정
      */
     fun submitVote(groupId: String, placeId: String) {
         val uid = auth.currentUser?.uid ?: return
@@ -447,8 +499,18 @@ class FinalVoteViewModel @Inject constructor(
                     android.util.Log.d("FinalVoteViewModel", 
                         "✅ 최종 투표 완료 - placeId: $placeId, uid: $uid")
                     
-                    // 투표 후 상태 다시 확인 (승리한 장소 확인을 위해)
+                    // 3. UI 표시용 투표 상태 업데이트
                     loadVoteStatus(groupId)
+                    
+                    // 4. ⭐ 내 투표 완료 후 충분한 지연을 두고 모든 사용자 완료 여부 확인 (Firestore 서버 동기화 시간 확보)
+                    kotlinx.coroutines.delay(1500)
+                    
+                    // 5. ⭐ 핵심: 내 투표 후에만 모든 사용자가 투표했는지 확인하고 승리 장소 결정
+                    // ⚠️ Firestore 동기화를 위한 지연 시간 필요 (다른 사용자의 투표가 반영되기 전)
+                    android.util.Log.d("FinalVoteViewModel", 
+                        "🔍 내 투표 저장 완료 후 모든 사용자 투표 완료 여부 확인 시작 (동기화 대기)")
+                    kotlinx.coroutines.delay(1500) // Firestore 동기화 시간 확보
+                    determineWinner(groupId)
                     
                     _voteSuccess.value = true
                 } else {

--- a/app/src/main/java/com/moyeoyo/app/ui/place/RecommendedPlaceActivity.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/place/RecommendedPlaceActivity.kt
@@ -1,5 +1,6 @@
 package com.moyeoyo.app.ui.place
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -42,6 +43,8 @@ class RecommendedPlaceActivity : AppCompatActivity(), OnMapReadyCallback {
     private var isMapReady = false
     private var selectedLocation: LatLngData? = null
     private var isRankMode = false
+    private var hasConfirmedRanking = false // 순위를 확정했는지 여부
+    private var hasShownAllCompletedDialog = false // 모든 사용자 완료 팝업 표시 여부 (중복 방지)
     private val selectedRanks = mutableMapOf<String, Int>() // placeId -> rank (1, 2, 3)
     private var currentRank = 1 // 다음 선택할 순위
 
@@ -80,6 +83,31 @@ class RecommendedPlaceActivity : AppCompatActivity(), OnMapReadyCallback {
         selectedLocation?.let {
             viewModel.loadNearbyPlaces(it)
         }
+        
+        // ⚠️ 중요: onCreate에서 hasConfirmedRanking은 항상 false로 시작
+        // 이전 세션의 Firestore 데이터와 현재 세션의 상태를 구분하기 위함
+        hasConfirmedRanking = false
+        
+        // Firestore에 이전 세션 데이터가 있는지만 확인 (hasUserRanking 설정용)
+        // 하지만 hasConfirmedRanking은 현재 세션에서 실제로 확정할 때만 true가 됨
+        viewModel.checkUserRankingStatus()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        // ⚠️ 중요: onResume에서도 hasConfirmedRanking을 false로 유지
+        // 현재 세션에서 실제로 확정하지 않았으면, Firestore에 데이터가 있어도 무시
+        // (사용자가 다른 기기에서 확정했을 수 있으므로 checkUserRankingStatus는 호출하되,
+        //  hasConfirmedRanking은 confirmAndSaveRankings()에서만 true로 설정됨)
+        
+        // 현재 사용자가 이미 순위를 확정했는지 다시 확인 (다른 기기에서 확정했을 수 있음)
+        // 단, hasConfirmedRanking은 현재 세션에서 확정했을 때만 true이므로
+        // 이전 세션 데이터가 있어도 현재 세션 상태를 유지
+        if (!hasConfirmedRanking) {
+            // 현재 세션에서 아직 확정하지 않았으면 Firestore 확인 (다른 기기에서 확정했을 수 있음)
+            // 하지만 hasConfirmedRanking은 변경하지 않음
+            viewModel.checkUserRankingStatus()
+        }
     }
 
     private fun setupViews() {
@@ -97,9 +125,15 @@ class RecommendedPlaceActivity : AppCompatActivity(), OnMapReadyCallback {
         }
 
         binding.btnProceedToVote.setOnClickListener {
+            if (!binding.btnProceedToVote.isEnabled) {
+                // 버튼이 비활성화되어 있으면 (다른 그룹원 완료 대기 중)
+                showWaitingDialog()
+                return@setOnClickListener
+            }
+            
             if (selectedRanks.size == 3) {
-                // 최종 투표 화면으로 이동
-                proceedToFinalVote()
+                // 3순위까지 모두 지정했으면 확정 팝업 표시
+                showConfirmRankingDialog()
             } else {
                 Toast.makeText(this, "3개 장소를 모두 선택해주세요.", Toast.LENGTH_SHORT).show()
             }
@@ -218,6 +252,75 @@ class RecommendedPlaceActivity : AppCompatActivity(), OnMapReadyCallback {
                 Toast.makeText(this, it, Toast.LENGTH_SHORT).show()
             }
         }
+
+        viewModel.rankingSaveSuccess.observe(this) { success ->
+            if (success) {
+                Toast.makeText(this, "순위 지정이 완료되었습니다.", Toast.LENGTH_SHORT).show()
+            }
+        }
+
+        // 1. 현재 "나"의 투표 상태만 관찰 (UI 업데이트용)
+        viewModel.hasUserRanking.observe(this) { hasRanking ->
+            // ⚠️ 핵심: hasUserRanking은 Firestore에 데이터가 있는지만 확인하는 용도
+            // 여기서는 checkAllUsersCompleted()를 호출하지 않음!
+            // checkAllUsersCompleted()는 오직 saveUserRankings() 내부에서만 호출됨
+            
+            android.util.Log.d("RecommendedPlaceActivity", 
+                "🔍 hasUserRanking 변경 - hasRanking: $hasRanking, hasConfirmedRanking: $hasConfirmedRanking")
+            
+            // 내가 투표를 확정한 경우에만 UI 업데이트
+            if (hasRanking && hasConfirmedRanking) {
+                // 내가 확정했고, Firestore에도 저장된 상태
+                binding.tvSelectedCount.text = "다른 그룹원의 순위 확정을 기다리는 중..."
+                binding.btnProceedToVote.isEnabled = false // 다른 사람이 끝날 때까지 비활성화
+                binding.btnProceedToVote.alpha = 0.5f
+                binding.btnProceedToVote.background = ContextCompat.getDrawable(this, R.drawable.bg_button_primary_disabled)
+                binding.btnRankMode.isEnabled = false // 순위 재선택 방지
+                binding.btnRankMode.alpha = 0.5f
+                
+                android.util.Log.d("RecommendedPlaceActivity", 
+                    "✅ 내 투표 확정 완료 - UI 업데이트 (버튼 비활성화)")
+            } else {
+                // 아직 확정하지 않았거나, Firestore에 데이터가 없는 경우
+                android.util.Log.d("RecommendedPlaceActivity", 
+                    "⏸️ 아직 확정하지 않음 - hasRanking: $hasRanking, hasConfirmedRanking: $hasConfirmedRanking")
+                binding.btnProceedToVote.isEnabled = false
+                binding.btnProceedToVote.alpha = 0.5f
+                binding.btnProceedToVote.background = ContextCompat.getDrawable(this, R.drawable.bg_button_primary_disabled)
+            }
+        }
+
+        // 2. "모든 사용자"의 완료 상태를 관찰 (화면 전환 트리거용)
+        viewModel.allUsersCompleted.observe(this) { allCompleted ->
+            android.util.Log.d("RecommendedPlaceActivity", 
+                "🔍 allUsersCompleted 변경 - allCompleted: $allCompleted, hasConfirmedRanking: $hasConfirmedRanking")
+            
+            // ⚠️ 핵심 조건: 모든 사용자가 완료했고, "나 자신도" 투표를 확정한 상태일 때만!
+            if (allCompleted && hasConfirmedRanking) {
+                // 버튼 활성화
+                binding.btnProceedToVote.isEnabled = true
+                binding.btnProceedToVote.alpha = 1.0f
+                binding.btnProceedToVote.background = ContextCompat.getDrawable(this, R.drawable.bg_button_primary)
+                
+                // ⚠️ 중요: Activity가 죽지 않았을 때만 팝업 표시
+                if (!isFinishing && !isDestroyed) {
+                    // 한 번만 팝업을 띄우기 위한 플래그
+                    if (!hasShownAllCompletedDialog) {
+                        hasShownAllCompletedDialog = true
+                        android.util.Log.d("RecommendedPlaceActivity", 
+                            "✅ 모든 사용자 완료! 확인 팝업 표시 및 화면 전환 준비")
+                        showAllCompletedDialog()
+                    }
+                }
+            } else {
+                // 아직 모든 사용자가 완료하지 않았거나, 내가 확정하지 않은 경우
+                android.util.Log.d("RecommendedPlaceActivity", 
+                    "⏸️ 아직 완료되지 않음 - allCompleted: $allCompleted, hasConfirmedRanking: $hasConfirmedRanking")
+                binding.btnProceedToVote.isEnabled = false
+                binding.btnProceedToVote.alpha = 0.5f
+                binding.btnProceedToVote.background = ContextCompat.getDrawable(this, R.drawable.bg_button_primary_disabled)
+            }
+        }
     }
 
     override fun onMapReady(map: GoogleMap) {
@@ -292,6 +395,12 @@ class RecommendedPlaceActivity : AppCompatActivity(), OnMapReadyCallback {
     }
 
     private fun toggleRankMode() {
+        // 이미 순위를 확정했다면 순위 선택 모드로 다시 들어갈 수 없음
+        if (hasConfirmedRanking) {
+            Toast.makeText(this, "이미 순위를 확정하셨습니다.", Toast.LENGTH_SHORT).show()
+            return
+        }
+        
         isRankMode = !isRankMode
         
         if (isRankMode) {
@@ -299,17 +408,25 @@ class RecommendedPlaceActivity : AppCompatActivity(), OnMapReadyCallback {
             binding.btnRankMode.visibility = View.VISIBLE
             selectedRanks.clear()
             currentRank = 1
+            // 순위 선택 모드 시작 시 하단 버튼 표시
+            binding.layoutBottomButton.visibility = View.VISIBLE
+            binding.btnProceedToVote.isEnabled = false
+            binding.btnProceedToVote.alpha = 0.5f
+            binding.btnProceedToVote.background = ContextCompat.getDrawable(this, R.drawable.bg_button_primary_disabled)
         } else {
             binding.btnRankMode.text = "순위 선택"
+            binding.btnRankMode.visibility = View.VISIBLE // 버튼은 계속 보이도록
             selectedRanks.clear()
             currentRank = 1
+            // 순위 선택 모드 종료 시 하단 버튼 숨김 (확정하지 않은 상태에서만)
+            if (!hasConfirmedRanking) {
+                binding.layoutBottomButton.visibility = View.GONE
+            }
         }
 
-        // 어댑터 업데이트 (스크롤 위치 유지)
-        adapter.updateRankMode(isRankMode, selectedRanks)
+        // 어댑터 업데이트 (스크롤 위치 유지) - 선택된 순위 초기화
+        adapter.updateRankMode(isRankMode, emptyMap())
         
-        // 하단 버튼 표시/숨김
-        binding.layoutBottomButton.visibility = if (isRankMode) View.VISIBLE else View.GONE
         updateSelectedCount()
     }
 
@@ -346,6 +463,11 @@ class RecommendedPlaceActivity : AppCompatActivity(), OnMapReadyCallback {
             
             updateSelectedCount()
             dialog.dismiss()
+            
+            // 3순위까지 모두 지정했으면 확정 팝업 표시
+            if (selectedRanks.size == 3) {
+                showConfirmRankingDialog()
+            }
         }
 
         dialogBinding.btnCancel.setOnClickListener {
@@ -359,14 +481,63 @@ class RecommendedPlaceActivity : AppCompatActivity(), OnMapReadyCallback {
         val count = selectedRanks.size
         binding.tvSelectedCount.text = "$count/3개 장소 선택됨"
         
-        binding.btnProceedToVote.isEnabled = count == 3
+        // 3개 선택되었고, 아직 확정하지 않은 상태에서만 버튼 활성화
+        // 확정 후에는 allUsersCompleted에 따라 활성화/비활성화
+        if (isRankMode && count == 3) {
+            // 순위 선택 모드 중이고 3개 선택했을 때만 활성화
+            val allCompleted = viewModel.allUsersCompleted.value ?: false
+            binding.btnProceedToVote.isEnabled = true
+            binding.btnProceedToVote.alpha = 1.0f
+            binding.btnProceedToVote.background = ContextCompat.getDrawable(this, R.drawable.bg_button_primary)
+        } else if (isRankMode) {
+            // 순위 선택 모드 중이지만 3개 미만 선택
+            binding.btnProceedToVote.isEnabled = false
+            binding.btnProceedToVote.alpha = 0.5f
+            binding.btnProceedToVote.background = ContextCompat.getDrawable(this, R.drawable.bg_button_primary_disabled)
+        }
+        // isRankMode가 false일 때는 confirmAndSaveRankings에서 이미 설정함
     }
 
-    private fun proceedToFinalVote() {
+    private fun showConfirmRankingDialog() {
+        // 선택된 장소 목록 만들기
+        val allPlaces = viewModel.places.value ?: emptyList()
+        val rankedPlacesList = mutableListOf<Pair<String, Int>>()
+        
+        allPlaces.forEach { place ->
+            val rank = selectedRanks[place.placeId]
+            if (rank != null) {
+                rankedPlacesList.add(place.name to rank)
+            }
+        }
+        
+        val sortedByRank = rankedPlacesList.sortedBy { it.second }
+        val message = sortedByRank.joinToString("\n") { (name, rank) ->
+            "${rank}순위: $name"
+        }
+        
+        AlertDialog.Builder(this)
+            .setTitle("순위 확정")
+            .setMessage("다음과 같이 순위를 지정하시겠습니까?\n\n$message\n\n확정하시면 다른 그룹원들이 순위 지정을 완료할 때까지 대기합니다.")
+            .setPositiveButton("확정") { _, _ ->
+                confirmAndSaveRankings()
+            }
+            .setNegativeButton("취소", null)
+            .setCancelable(false)
+            .show()
+    }
+
+    private fun confirmAndSaveRankings() {
         // 선택된 장소들로 RankedPlace 생성
+        val allPlaces = viewModel.places.value
+        if (allPlaces.isNullOrEmpty()) {
+            Toast.makeText(this, "장소 정보를 불러올 수 없습니다. 다시 시도해주세요.", Toast.LENGTH_SHORT).show()
+            return
+        }
+        
         val rankedPlaces = mutableListOf<RankedPlace>()
         
-        viewModel.filteredPlaces.value?.forEach { place ->
+        // 전체 장소 목록에서 사용자가 선택한 장소 찾기
+        allPlaces.forEach { place ->
             val rank = selectedRanks[place.placeId]
             if (rank != null) {
                 val score = when (rank) {
@@ -379,15 +550,93 @@ class RecommendedPlaceActivity : AppCompatActivity(), OnMapReadyCallback {
             }
         }
 
-        // 최종 투표 화면으로 이동
+        if (rankedPlaces.size != 3) {
+            Toast.makeText(this, "선택된 3개 장소 정보를 찾을 수 없습니다. 다시 선택해주세요.", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        // Firestore에 저장 (모든 사용자 완료 확인은 ViewModel의 saveUserRankings 내부에서 처리)
+        viewModel.saveUserRankings(rankedPlaces.sortedBy { it.rank })
+        
+        // 순위 확정 완료
+        hasConfirmedRanking = true
+        
+        // 순위 선택 모드 해제 (버튼은 숨기지 않고 비활성화 상태 유지)
+        isRankMode = false
+        binding.btnRankMode.text = "순위 선택"
+        adapter.updateRankMode(false, emptyMap())
+        
+        // 선택된 순위 초기화
+        selectedRanks.clear()
+        currentRank = 1
+        
+        // 하단 버튼은 계속 표시하되 비활성화 상태로 변경
+        binding.layoutBottomButton.visibility = View.VISIBLE
+        binding.btnProceedToVote.isEnabled = false
+        binding.btnProceedToVote.alpha = 0.5f
+        binding.btnProceedToVote.background = ContextCompat.getDrawable(this, R.drawable.bg_button_primary_disabled)
+        binding.tvSelectedCount.text = "다른 그룹원의 순위 확정을 기다리는 중..."
+        
+        // checkAllUsersCompleted는 saveUserRankings 내부에서 호출되므로 여기서는 중복 호출 제거
+    }
+
+    private fun showWaitingDialog() {
+        AlertDialog.Builder(this)
+            .setTitle("대기 중")
+            .setMessage("현재 다른 그룹원의 최종 순위 확정을 기다리는 중입니다.\n모든 그룹원이 순위를 확정하면 최종 투표를 진행할 수 있습니다.")
+            .setPositiveButton("확인", null)
+            .show()
+    }
+
+    /**
+     * 모든 그룹원이 순위를 확정했을 때 자동으로 표시되는 확인 팝업
+     */
+    private fun showAllCompletedDialog() {
+        AlertDialog.Builder(this)
+            .setTitle("모든 그룹원 완료")
+            .setMessage("모든 그룹원이 순위를 확정했습니다.\n최종 투표를 진행하시겠습니까?")
+            .setPositiveButton("진행하기") { _, _ ->
+                navigateToFinalVote()
+            }
+            .setNegativeButton("나중에", null)
+            .setCancelable(false)
+            .show()
+    }
+
+    /**
+     * 최종 투표 화면으로 이동
+     */
+    private fun navigateToFinalVote() {
+        // FinalVoteActivity는 Firestore에서 모든 사용자의 순위를 불러와서 집계하므로
+        // groupId만 전달하면 됨 (더 안전하고 확실한 방식)
         val groupId = intent.getStringExtra("groupId") ?: ""
-        val intent = android.content.Intent(this, FinalVoteActivity::class.java).apply {
+        if (groupId.isEmpty()) {
+            Toast.makeText(this, "그룹 정보를 찾을 수 없습니다.", Toast.LENGTH_SHORT).show()
+            return
+        }
+        
+        android.util.Log.d("RecommendedPlaceActivity", 
+            "🚀 최종 투표 화면으로 이동 - groupId: $groupId")
+        
+        val intent = Intent(this, FinalVoteActivity::class.java).apply {
             putExtra("groupId", groupId)
-            putParcelableArrayListExtra("rankedPlaces", ArrayList(rankedPlaces.map { 
-                RankedPlaceParcelable.from(it) 
-            }))
+            // 중복 실행 방지 플래그
+            addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
         }
         startActivity(intent)
+        // 현재 화면은 닫지 않음 (사용자가 뒤로가기를 눌러 돌아올 수 있도록)
+    }
+
+    private fun proceedToFinalVote() {
+        // 모든 사용자가 완료했는지 확인
+        val allCompleted = viewModel.allUsersCompleted.value ?: false
+        if (!allCompleted) {
+            showWaitingDialog()
+            return
+        }
+        
+        // 이미 모든 사용자가 완료한 상태이므로 바로 이동 (확인 팝업은 이미 표시됨)
+        navigateToFinalVote()
     }
 }
 

--- a/app/src/main/java/com/moyeoyo/app/ui/place/RecommendedPlaceAdapter.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/place/RecommendedPlaceAdapter.kt
@@ -47,10 +47,10 @@ class RecommendedPlaceAdapter(
      */
     fun updateRankMode(isRankMode: Boolean, selectedRanks: Map<String, Int>) {
         val oldIsRankMode = this.isRankMode
-        val oldSelectedRanks = this.selectedRanks
+        val oldSelectedRanks = this.selectedRanks.toMap() // 복사본 생성
         
         this.isRankMode = isRankMode
-        this.selectedRanks = selectedRanks
+        this.selectedRanks = selectedRanks.toMap() // 복사본으로 저장
         
         // 순위 모드가 변경되었거나, 선택된 순위가 변경된 아이템만 업데이트
         if (oldIsRankMode != isRankMode) {
@@ -58,15 +58,14 @@ class RecommendedPlaceAdapter(
             notifyItemRangeChanged(0, itemCount)
         } else {
             // 순위 모드가 같으면 변경된 아이템만 업데이트
-            val allPlaceIds = (oldSelectedRanks.keys + selectedRanks.keys).toSet()
             for (i in 0 until itemCount) {
                 val place = getItem(i)
-                if (place.placeId in allPlaceIds) {
-                    val oldRank = oldSelectedRanks[place.placeId]
-                    val newRank = selectedRanks[place.placeId]
-                    if (oldRank != newRank) {
-                        notifyItemChanged(i)
-                    }
+                val placeId = place.placeId
+                val oldRank = oldSelectedRanks[placeId]
+                val newRank = selectedRanks[placeId]
+                // 순위가 변경되었거나 새로 선택/해제된 경우 업데이트
+                if (oldRank != newRank) {
+                    notifyItemChanged(i)
                 }
             }
         }
@@ -115,40 +114,17 @@ class RecommendedPlaceAdapter(
                 binding.tvTransitTime.visibility = View.GONE
             }
 
-            // 순위 모드인 경우 순위 표시
-            if (isRankMode) {
-                val rank = selectedRanks[place.placeId]
-                if (rank != null) {
-                    binding.tvRankBadge.visibility = View.VISIBLE
-                    binding.tvRankBadge.text = rank.toString()
-                    // 순위별 색상 변경
-                    binding.root.background = ContextCompat.getDrawable(
-                        binding.root.context,
-                        when (rank) {
-                            1 -> R.drawable.bg_rank_badge
-                            2 -> R.drawable.bg_rank_badge
-                            3 -> R.drawable.bg_rank_badge
-                            else -> R.drawable.bg_card
-                        }
-                    )
-                    // 순위 배지 색상
-                    binding.tvRankBadge.background = ContextCompat.getDrawable(
-                        binding.root.context,
-                        when (rank) {
-                            1 -> R.drawable.bg_rank_badge // 1순위 - 파란색
-                            2 -> R.drawable.bg_rank_badge // 2순위 - 초록색
-                            3 -> R.drawable.bg_rank_badge // 3순위 - 노란색
-                            else -> R.drawable.bg_rank_badge
-                        }
-                    )
-                } else {
-                    binding.tvRankBadge.visibility = View.GONE
-                    binding.root.background = ContextCompat.getDrawable(
-                        binding.root.context,
-                        R.drawable.bg_card
-                    )
-                }
+            // 순위 모드인 경우 순위 표시 및 배경 변경
+            val rank = if (isRankMode) selectedRanks[place.placeId] else null
+            if (rank != null) {
+                // 선택된 장소: 선택 효과 배경 적용 (진한 파란색 배경 + 파란색 테두리)
+                binding.cardContainer.setBackgroundResource(R.drawable.bg_card_selected)
+                binding.tvRankBadge.visibility = View.VISIBLE
+                binding.tvRankBadge.text = rank.toString()
+                binding.tvRankBadge.setBackgroundResource(R.drawable.bg_rank_badge)
             } else {
+                // 선택되지 않은 장소: 기본 배경
+                binding.cardContainer.setBackgroundResource(R.drawable.bg_card)
                 binding.tvRankBadge.visibility = View.GONE
             }
 

--- a/app/src/main/java/com/moyeoyo/app/ui/place/RecommendedPlaceViewModel.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/place/RecommendedPlaceViewModel.kt
@@ -8,7 +8,9 @@ import com.moyeoyo.app.data.model.InputLocation
 import com.moyeoyo.app.data.model.LatLngData
 import com.moyeoyo.app.data.model.NearbyPlace
 import com.moyeoyo.app.data.model.PlaceCategory
+import com.moyeoyo.app.data.model.RankedPlace
 import com.moyeoyo.app.data.model.TransportMode
+import com.moyeoyo.app.data.repository.GroupRepository
 import com.moyeoyo.app.data.repository.MapRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -16,7 +18,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class RecommendedPlaceViewModel @Inject constructor(
-    private val mapRepository: MapRepository
+    private val mapRepository: MapRepository,
+    private val groupRepository: GroupRepository
 ) : ViewModel() {
 
     private val _places = MutableLiveData<List<NearbyPlace>>(emptyList())
@@ -38,6 +41,12 @@ class RecommendedPlaceViewModel @Inject constructor(
     private val _transitTimes = MutableLiveData<Map<String, Int>>(emptyMap())
     val transitTimes: LiveData<Map<String, Int>> = _transitTimes
     
+    private val _rankingSaveSuccess = MutableLiveData<Boolean>(false)
+    val rankingSaveSuccess: LiveData<Boolean> = _rankingSaveSuccess
+    
+    private val _allUsersCompleted = MutableLiveData<Boolean>(false)
+    val allUsersCompleted: LiveData<Boolean> = _allUsersCompleted
+    
     private var currentSelectedPlaceId: String? = null
 
     // 그룹원들의 입력 위치 목록
@@ -47,6 +56,9 @@ class RecommendedPlaceViewModel @Inject constructor(
     private var centerLocation: LatLngData? = null
     private var groupId: String? = null
     private var userInputLocation: InputLocation? = null
+    
+    private val _hasUserRanking = MutableLiveData<Boolean>(false)
+    val hasUserRanking: LiveData<Boolean> = _hasUserRanking
 
     /**
      * 그룹 ID 설정
@@ -179,6 +191,189 @@ class RecommendedPlaceViewModel @Inject constructor(
         // 평점 높은 순으로 정렬 후 상위 10개만
         val sorted = filtered.sortedByDescending { it.rating ?: 0.0 }.take(10)
         _filteredPlaces.value = sorted
+    }
+
+    /**
+     * 사용자별 순위 지정 저장
+     */
+    fun saveUserRankings(rankedPlaces: List<RankedPlace>) {
+        val id = groupId ?: return
+        _rankingSaveSuccess.value = false
+        
+        viewModelScope.launch {
+            try {
+                android.util.Log.d("RecommendedPlaceViewModel", 
+                    "💾 순위 저장 시작 - groupId: $id, 순위 개수: ${rankedPlaces.size}")
+                
+                mapRepository.saveUserRankings(id, rankedPlaces)
+                _rankingSaveSuccess.value = true
+                
+                android.util.Log.d("RecommendedPlaceViewModel", "✅ 순위 저장 완료")
+                
+                // 저장 완료 후 hasUserRanking을 true로 설정 (UI 업데이트용 observer 트리거)
+                // ⚠️ 중요: 이 시점에 hasUserRanking을 true로 설정하면,
+                // Activity의 hasUserRanking observer가 트리거되어 UI가 업데이트됩니다.
+                // 하지만 checkAllUsersCompleted()는 여기서만 호출하므로 중복 호출 방지!
+                _hasUserRanking.value = true
+                
+                // 저장 완료 후 충분한 지연을 두고 완료 여부 확인 (Firestore 서버 동기화 시간 확보)
+                // Source.SERVER를 사용하더라도 서버에 데이터가 반영되는데 시간이 걸릴 수 있음
+                kotlinx.coroutines.delay(1500)
+                
+                // ⚠️ 핵심: checkAllUsersCompleted()는 오직 여기서만 호출!
+                // 다른 곳(observer 등)에서는 절대 호출하지 않음!
+                android.util.Log.d("RecommendedPlaceViewModel", 
+                    "🔍 내 투표 저장 완료 후 모든 사용자 완료 여부 확인 시작")
+                checkAllUsersCompletedWithRetry()
+            } catch (e: Exception) {
+                android.util.Log.e("RecommendedPlaceViewModel", 
+                    "❌ 순위 저장 실패: ${e.message}", e)
+                _error.value = "순위 저장에 실패했습니다: ${e.message}"
+                _rankingSaveSuccess.value = false
+            }
+        }
+    }
+
+    /**
+     * 현재 사용자가 이미 순위를 확정했는지 확인
+     */
+    fun checkUserRankingStatus() {
+        val id = groupId ?: return
+        val uid = mapRepository.currentUserId() ?: return
+        
+        viewModelScope.launch {
+            try {
+                // Source.SERVER를 사용하여 서버에서 직접 가져오기 (캐시 무시)
+                val userRankings = mapRepository.getUserRankings(
+                    id, 
+                    uid, 
+                    com.google.firebase.firestore.Source.SERVER
+                )
+                _hasUserRanking.value = userRankings.isNotEmpty()
+                
+                android.util.Log.d("RecommendedPlaceViewModel", 
+                    "🔍 현재 사용자 순위 확인 - uid: $uid, 순위 개수: ${userRankings.size}, hasRanking: ${_hasUserRanking.value}")
+            } catch (e: Exception) {
+                android.util.Log.e("RecommendedPlaceViewModel", 
+                    "❌ 사용자 순위 확인 실패: ${e.message}", e)
+                _hasUserRanking.value = false
+            }
+        }
+    }
+
+    /**
+     * 모든 사용자가 순위 지정을 완료했는지 확인
+     * ⚠️ Deprecated: 이 함수는 더 이상 사용되지 않습니다.
+     * 대신 checkAllUsersCompletedWithRetry()를 사용하세요.
+     * checkAllUsersCompleted()는 오직 saveUserRankings() 내부에서만 호출되어야 합니다.
+     */
+    @Deprecated("Use checkAllUsersCompletedWithRetry() instead")
+    fun checkAllUsersCompleted() {
+        val id = groupId ?: return
+        
+        viewModelScope.launch {
+            try {
+                val group = groupRepository.getGroupById(id)
+                val totalMembers = group?.memberUids?.size ?: 0
+                val completedCount = mapRepository.getCompletedRankingCount(id)
+                
+                android.util.Log.d("RecommendedPlaceViewModel", 
+                    "🔍 완료 확인 - 총 멤버: $totalMembers, 완료된 수: $completedCount, groupId: $id")
+                
+                _allUsersCompleted.value = totalMembers > 0 && completedCount >= totalMembers
+                
+                android.util.Log.d("RecommendedPlaceViewModel", 
+                    "✅ 모든 사용자 완료 여부: ${_allUsersCompleted.value}")
+            } catch (e: Exception) {
+                android.util.Log.e("RecommendedPlaceViewModel", 
+                    "❌ 완료 상태 확인 실패: ${e.message}", e)
+                _error.value = "완료 상태 확인에 실패했습니다: ${e.message}"
+                _allUsersCompleted.value = false
+            }
+        }
+    }
+
+    /**
+     * 모든 사용자가 순위 지정을 완료했는지 확인 (재시도 로직 포함)
+     * Firestore 서버 동기화 지연을 고려하여 최대 5회까지 재시도
+     * 각 재시도마다 실제 그룹 멤버 수와 완료된 사용자 수를 비교하여 정확성 보장
+     */
+    private fun checkAllUsersCompletedWithRetry(maxRetries: Int = 5) {
+        val id = groupId ?: return
+        
+        viewModelScope.launch {
+            var retryCount = 0
+            var allCompleted = false
+            
+            while (retryCount < maxRetries && !allCompleted) {
+                try {
+                    val group = groupRepository.getGroupById(id)
+                    val totalMembers = group?.memberUids?.size ?: 0
+                    val completedCount = mapRepository.getCompletedRankingCount(id)
+                    
+                    android.util.Log.d("RecommendedPlaceViewModel", 
+                        "🔍 완료 확인 (시도 ${retryCount + 1}/$maxRetries) - 총 멤버: $totalMembers, 완료된 수: $completedCount, groupId: $id")
+                    
+                    // ⚠️ 중요: 완료된 수가 총 멤버 수와 정확히 일치해야만 완료로 판단
+                    // completedCount >= totalMembers는 위험할 수 있음 (이전 세션 데이터 포함 가능)
+                    val countMatches = totalMembers > 0 && completedCount == totalMembers
+                    
+                    if (countMatches) {
+                        // 모든 사용자가 완료되었는지 한 번 더 확인 (정확성 보장)
+                        // 실제로 각 멤버의 순위 데이터가 존재하는지 확인
+                        val allRankings = mapRepository.getAllUserRankings(id)
+                        val actualCompletedCount = allRankings.values.count { it.isNotEmpty() }
+                        
+                        android.util.Log.d("RecommendedPlaceViewModel", 
+                            "🔍 실제 데이터 확인 - 문서 수: $completedCount, 실제 완료: $actualCompletedCount, 총 멤버: $totalMembers")
+                        
+                        if (actualCompletedCount == totalMembers) {
+                            allCompleted = true
+                            _allUsersCompleted.value = true
+                            android.util.Log.d("RecommendedPlaceViewModel", 
+                                "✅ 모든 사용자 완료 여부: true (시도 ${retryCount + 1}/$maxRetries, 실제 완료: $actualCompletedCount/$totalMembers)")
+                            return@launch
+                        } else {
+                            android.util.Log.d("RecommendedPlaceViewModel", 
+                                "⏸️ 문서 수는 일치하지만 실제 데이터 확인 실패 - 실제 완료: $actualCompletedCount/$totalMembers")
+                        }
+                    } else {
+                        android.util.Log.d("RecommendedPlaceViewModel", 
+                            "⏸️ 완료 수 불일치 - 완료: $completedCount, 총 멤버: $totalMembers")
+                    }
+                    
+                    // 아직 완료되지 않았고 재시도 가능하면 잠시 대기 후 재시도
+                    if (retryCount < maxRetries - 1) {
+                        // 재시도 전에 지연 시간 증가 (지수 백오프)
+                        val delayMs = 800L * (retryCount + 1)
+                        android.util.Log.d("RecommendedPlaceViewModel", 
+                            "⏳ 모든 사용자 미완료 - ${delayMs}ms 후 재시도 (${retryCount + 1}/$maxRetries)")
+                        kotlinx.coroutines.delay(delayMs)
+                    }
+                    
+                    retryCount++
+                } catch (e: Exception) {
+                    android.util.Log.e("RecommendedPlaceViewModel", 
+                        "❌ 완료 상태 확인 실패 (시도 ${retryCount + 1}/$maxRetries): ${e.message}", e)
+                    
+                    if (retryCount < maxRetries - 1) {
+                        kotlinx.coroutines.delay(800L * (retryCount + 1))
+                        retryCount++
+                    } else {
+                        _error.value = "완료 상태 확인에 실패했습니다: ${e.message}"
+                        _allUsersCompleted.value = false
+                        return@launch
+                    }
+                }
+            }
+            
+            // 모든 재시도 후에도 완료되지 않음
+            if (!allCompleted) {
+                _allUsersCompleted.value = false
+                android.util.Log.d("RecommendedPlaceViewModel", 
+                    "⏸️ 아직 모든 사용자가 완료하지 않음 (최대 재시도 횟수 도달)")
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/moyeoyo/app/ui/place/RecommendedPlaceViewModel.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/place/RecommendedPlaceViewModel.kt
@@ -10,9 +10,12 @@ import com.moyeoyo.app.data.model.NearbyPlace
 import com.moyeoyo.app.data.model.PlaceCategory
 import com.moyeoyo.app.data.model.RankedPlace
 import com.moyeoyo.app.data.model.TransportMode
+import com.moyeoyo.app.data.model.Vote
 import com.moyeoyo.app.data.repository.GroupRepository
 import com.moyeoyo.app.data.repository.MapRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -61,10 +64,45 @@ class RecommendedPlaceViewModel @Inject constructor(
     val hasUserRanking: LiveData<Boolean> = _hasUserRanking
 
     /**
-     * 그룹 ID 설정
+     * 그룹 ID 설정 및 vote 문서 리스너 시작
+     * ⭐ 새로운 구조: vote 문서를 관찰하여 상태 변경 감지
      */
     fun setGroupId(id: String) {
         groupId = id
+        
+        // vote 문서 실시간 리스너 시작
+        startListeningToVoteStatus(id)
+    }
+
+    /**
+     * vote 문서 실시간 리스너 시작
+     * ⭐ 새로운 구조: vote 문서의 status를 관찰하여 FINAL_VOTING 상태가 되면 allUsersCompleted를 true로 설정
+     */
+    private fun startListeningToVoteStatus(groupId: String) {
+        groupRepository.listenToVoteStatus(groupId)
+            .onEach { vote ->
+                if (vote != null) {
+                    android.util.Log.d("RecommendedPlaceViewModel", 
+                        "🔍 vote 문서 업데이트 - status: ${vote.status}, rankedUsers: ${vote.rankedUsers.size}명")
+                    
+                    // vote 문서의 status가 FINAL_VOTING이 되면 모든 사용자가 순위 지정을 완료한 것으로 판단
+                    if (vote.status == "FINAL_VOTING") {
+                        android.util.Log.d("RecommendedPlaceViewModel", 
+                            "✅ vote 문서 상태가 FINAL_VOTING으로 변경됨 - 모든 사용자 순위 지정 완료!")
+                        _allUsersCompleted.value = true
+                    } else {
+                        // RANKING 상태인 경우 rankedUsers 배열 확인
+                        // members 배열과 rankedUsers 배열 비교
+                        viewModelScope.launch {
+                            val allRanked = groupRepository.checkAllUsersRanked(groupId)
+                            android.util.Log.d("RecommendedPlaceViewModel", 
+                                "🔍 RANKING 상태 확인 - allRanked: $allRanked")
+                            _allUsersCompleted.value = allRanked
+                        }
+                    }
+                }
+            }
+            .launchIn(viewModelScope)
     }
 
     /**
@@ -198,6 +236,7 @@ class RecommendedPlaceViewModel @Inject constructor(
      */
     fun saveUserRankings(rankedPlaces: List<RankedPlace>) {
         val id = groupId ?: return
+        val uid = mapRepository.currentUserId() ?: return
         _rankingSaveSuccess.value = false
         
         viewModelScope.launch {
@@ -205,26 +244,26 @@ class RecommendedPlaceViewModel @Inject constructor(
                 android.util.Log.d("RecommendedPlaceViewModel", 
                     "💾 순위 저장 시작 - groupId: $id, 순위 개수: ${rankedPlaces.size}")
                 
+                // 1. 사용자별 순위 지정을 userRankings에 저장 (기존 로직 유지)
                 mapRepository.saveUserRankings(id, rankedPlaces)
+                
+                // 2. vote 문서의 rankedUsers 배열에 현재 사용자 추가 (⭐ 새로운 구조)
+                groupRepository.addUserToRankedList(id, uid)
+                
                 _rankingSaveSuccess.value = true
                 
-                android.util.Log.d("RecommendedPlaceViewModel", "✅ 순위 저장 완료")
+                android.util.Log.d("RecommendedPlaceViewModel", "✅ 순위 저장 완료 및 rankedUsers 업데이트")
                 
                 // 저장 완료 후 hasUserRanking을 true로 설정 (UI 업데이트용 observer 트리거)
-                // ⚠️ 중요: 이 시점에 hasUserRanking을 true로 설정하면,
-                // Activity의 hasUserRanking observer가 트리거되어 UI가 업데이트됩니다.
-                // 하지만 checkAllUsersCompleted()는 여기서만 호출하므로 중복 호출 방지!
                 _hasUserRanking.value = true
                 
                 // 저장 완료 후 충분한 지연을 두고 완료 여부 확인 (Firestore 서버 동기화 시간 확보)
-                // Source.SERVER를 사용하더라도 서버에 데이터가 반영되는데 시간이 걸릴 수 있음
                 kotlinx.coroutines.delay(1500)
                 
-                // ⚠️ 핵심: checkAllUsersCompleted()는 오직 여기서만 호출!
-                // 다른 곳(observer 등)에서는 절대 호출하지 않음!
+                // ⚠️ 핵심: vote 문서의 rankedUsers 배열을 확인하여 모든 사용자 완료 여부 판단
                 android.util.Log.d("RecommendedPlaceViewModel", 
-                    "🔍 내 투표 저장 완료 후 모든 사용자 완료 여부 확인 시작")
-                checkAllUsersCompletedWithRetry()
+                    "🔍 vote 문서 확인 - 모든 사용자 순위 지정 완료 여부 확인 시작")
+                checkAllUsersRankedWithRetry()
             } catch (e: Exception) {
                 android.util.Log.e("RecommendedPlaceViewModel", 
                     "❌ 순위 저장 실패: ${e.message}", e)
@@ -295,10 +334,10 @@ class RecommendedPlaceViewModel @Inject constructor(
 
     /**
      * 모든 사용자가 순위 지정을 완료했는지 확인 (재시도 로직 포함)
+     * ⭐ 새로운 구조: vote 문서의 rankedUsers 배열을 확인하여 정확한 상태 판단
      * Firestore 서버 동기화 지연을 고려하여 최대 5회까지 재시도
-     * 각 재시도마다 실제 그룹 멤버 수와 완료된 사용자 수를 비교하여 정확성 보장
      */
-    private fun checkAllUsersCompletedWithRetry(maxRetries: Int = 5) {
+    private fun checkAllUsersRankedWithRetry(maxRetries: Int = 5) {
         val id = groupId ?: return
         
         viewModelScope.launch {
@@ -307,39 +346,21 @@ class RecommendedPlaceViewModel @Inject constructor(
             
             while (retryCount < maxRetries && !allCompleted) {
                 try {
-                    val group = groupRepository.getGroupById(id)
-                    val totalMembers = group?.memberUids?.size ?: 0
-                    val completedCount = mapRepository.getCompletedRankingCount(id)
+                    // ⭐ vote 문서의 rankedUsers 배열을 확인 (Single Source of Truth)
+                    val allRanked = groupRepository.checkAllUsersRanked(id)
                     
                     android.util.Log.d("RecommendedPlaceViewModel", 
-                        "🔍 완료 확인 (시도 ${retryCount + 1}/$maxRetries) - 총 멤버: $totalMembers, 완료된 수: $completedCount, groupId: $id")
+                        "🔍 vote 문서 확인 (시도 ${retryCount + 1}/$maxRetries) - groupId: $id, allRanked: $allRanked")
                     
-                    // ⚠️ 중요: 완료된 수가 총 멤버 수와 정확히 일치해야만 완료로 판단
-                    // completedCount >= totalMembers는 위험할 수 있음 (이전 세션 데이터 포함 가능)
-                    val countMatches = totalMembers > 0 && completedCount == totalMembers
-                    
-                    if (countMatches) {
-                        // 모든 사용자가 완료되었는지 한 번 더 확인 (정확성 보장)
-                        // 실제로 각 멤버의 순위 데이터가 존재하는지 확인
-                        val allRankings = mapRepository.getAllUserRankings(id)
-                        val actualCompletedCount = allRankings.values.count { it.isNotEmpty() }
-                        
+                    if (allRanked) {
+                        allCompleted = true
+                        _allUsersCompleted.value = true
                         android.util.Log.d("RecommendedPlaceViewModel", 
-                            "🔍 실제 데이터 확인 - 문서 수: $completedCount, 실제 완료: $actualCompletedCount, 총 멤버: $totalMembers")
-                        
-                        if (actualCompletedCount == totalMembers) {
-                            allCompleted = true
-                            _allUsersCompleted.value = true
-                            android.util.Log.d("RecommendedPlaceViewModel", 
-                                "✅ 모든 사용자 완료 여부: true (시도 ${retryCount + 1}/$maxRetries, 실제 완료: $actualCompletedCount/$totalMembers)")
-                            return@launch
-                        } else {
-                            android.util.Log.d("RecommendedPlaceViewModel", 
-                                "⏸️ 문서 수는 일치하지만 실제 데이터 확인 실패 - 실제 완료: $actualCompletedCount/$totalMembers")
-                        }
+                            "✅ 모든 사용자 순위 지정 완료! (시도 ${retryCount + 1}/$maxRetries)")
+                        return@launch
                     } else {
                         android.util.Log.d("RecommendedPlaceViewModel", 
-                            "⏸️ 완료 수 불일치 - 완료: $completedCount, 총 멤버: $totalMembers")
+                            "⏸️ 아직 모든 사용자가 순위 지정을 완료하지 않음")
                     }
                     
                     // 아직 완료되지 않았고 재시도 가능하면 잠시 대기 후 재시도

--- a/app/src/main/java/com/moyeoyo/app/ui/place/RecommendedPlaceViewModel.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/place/RecommendedPlaceViewModel.kt
@@ -70,35 +70,102 @@ class RecommendedPlaceViewModel @Inject constructor(
     fun setGroupId(id: String) {
         groupId = id
         
+        // ⭐ Activity 시작 시 vote 문서 상태 확인 및 초기화 (이전 테스트 데이터 정리)
+        viewModelScope.launch {
+            try {
+                val voteStatus = groupRepository.getVoteStatus(id)
+                if (voteStatus?.status == "FINISHED") {
+                    android.util.Log.d("RecommendedPlaceViewModel", 
+                        "⚠️ vote 문서가 FINISHED 상태입니다. 이전 테스트 데이터를 초기화합니다.")
+                    groupRepository.resetVoteStatus(id)
+                    android.util.Log.d("RecommendedPlaceViewModel", 
+                        "✅ vote 문서를 RANKING 상태로 초기화했습니다.")
+                }
+            } catch (e: Exception) {
+                android.util.Log.e("RecommendedPlaceViewModel", 
+                    "❌ vote 문서 상태 확인 실패: ${e.message}", e)
+            }
+        }
+        
         // vote 문서 실시간 리스너 시작
         startListeningToVoteStatus(id)
     }
 
     /**
-     * vote 문서 실시간 리스너 시작
-     * ⭐ 새로운 구조: vote 문서의 status를 관찰하여 FINAL_VOTING 상태가 되면 allUsersCompleted를 true로 설정
+     * ⭐ [역할 축소] 오직 '1차 투표 완료' 여부만 감시하는 단순화된 리스너
+     * FINAL_VOTING이나 FINISHED 상태는 이 ViewModel의 관심사가 아님
      */
     private fun startListeningToVoteStatus(groupId: String) {
         groupRepository.listenToVoteStatus(groupId)
             .onEach { vote ->
-                if (vote != null) {
+                if (vote == null) return@onEach
+                
+                android.util.Log.d("RecommendedPlaceViewModel", 
+                    "🎧 1차 투표 리스너: status=${vote.status}, rankedUsers=${vote.rankedUsers.size}명")
+                
+                // ⚠️ FINISHED 상태는 이전 테스트의 데이터일 수 있으므로 무시
+                if (vote.status == "FINISHED") {
                     android.util.Log.d("RecommendedPlaceViewModel", 
-                        "🔍 vote 문서 업데이트 - status: ${vote.status}, rankedUsers: ${vote.rankedUsers.size}명")
+                        "⏸️ FINISHED 상태 무시 (이전 테스트 데이터)")
+                    return@onEach
+                }
+                
+                // ⚠️ FINAL_VOTING 상태 처리: 이미 최종 투표 단계로 넘어간 상태
+                // FINAL_VOTING 상태는 이미 모든 사용자가 1차 투표를 완료한 상태
+                // ⚠️ 핵심: 현재 사용자가 이미 확정한 경우에만 allUsersCompleted를 true로 설정
+                // Firestore에 데이터가 있다고 해서 확정한 것은 아니므로, 현재 세션에서 확정한 경우만 처리
+                if (vote.status == "FINAL_VOTING") {
+                    android.util.Log.d("RecommendedPlaceViewModel", 
+                        "✅ FINAL_VOTING 상태 감지 - rankedUsers: ${vote.rankedUsers.size}명, _hasUserRanking: ${_hasUserRanking.value}")
                     
-                    // vote 문서의 status가 FINAL_VOTING이 되면 모든 사용자가 순위 지정을 완료한 것으로 판단
-                    if (vote.status == "FINAL_VOTING") {
-                        android.util.Log.d("RecommendedPlaceViewModel", 
-                            "✅ vote 문서 상태가 FINAL_VOTING으로 변경됨 - 모든 사용자 순위 지정 완료!")
-                        _allUsersCompleted.value = true
+                    // ⚠️ 핵심: 현재 사용자가 이미 확정한 경우에만 화면 전환 가능
+                    // 단순히 Firestore에 데이터가 있다고 해서 확정한 것은 아님
+                    // saveUserRankings()에서 _hasUserRanking.value = true 설정 후에만 여기로 올 수 있음
+                    if (_hasUserRanking.value == true) {
+                        viewModelScope.launch {
+                            // 한 번 더 확인하여 모든 사용자가 확정했는지 검증
+                            val allRanked = groupRepository.checkAllUsersRanked(groupId)
+                            android.util.Log.d("RecommendedPlaceViewModel", 
+                                "🔍 FINAL_VOTING 상태 - 모든 사용자 완료 여부 확인: allRanked=$allRanked")
+                            
+                            // 모든 사용자가 확정한 경우에만 allUsersCompleted 설정
+                            if (allRanked) {
+                                _allUsersCompleted.value = true
+                                android.util.Log.d("RecommendedPlaceViewModel", 
+                                    "✅ FINAL_VOTING 상태에서 allUsersCompleted = true 설정 (화면 전환 가능)")
+                            } else {
+                                android.util.Log.d("RecommendedPlaceViewModel", 
+                                    "⏸️ FINAL_VOTING 상태이지만 아직 모든 사용자가 확정하지 않음")
+                            }
+                        }
                     } else {
-                        // RANKING 상태인 경우 rankedUsers 배열 확인
-                        // members 배열과 rankedUsers 배열 비교
+                        android.util.Log.d("RecommendedPlaceViewModel", 
+                            "⏸️ FINAL_VOTING 상태이지만 현재 사용자가 아직 확정하지 않음 - 대기")
+                    }
+                    return@onEach
+                }
+                
+                // ⭐ 오직 RANKING 상태일 때만 처리
+                if (vote.status == "RANKING") {
+                    // 현재 사용자가 이미 확정한 경우에만 다른 사용자들의 완료 여부 확인
+                    if (_hasUserRanking.value == true) {
                         viewModelScope.launch {
                             val allRanked = groupRepository.checkAllUsersRanked(groupId)
                             android.util.Log.d("RecommendedPlaceViewModel", 
-                                "🔍 RANKING 상태 확인 - allRanked: $allRanked")
+                                "🔍 RANKING 상태 확인 (다른 사용자 확정 감지) - allRanked: $allRanked")
+                            
+                            // ⭐ 리스너는 오직 '모두 완료되었는가' 라는 사실만 전달
+                            // 상태를 변경하지 않고, 단순히 완료 여부만 알림
                             _allUsersCompleted.value = allRanked
+                            
+                            if (allRanked) {
+                                android.util.Log.d("RecommendedPlaceViewModel", 
+                                    "✅ 모든 사용자 1차 투표 완료 감지!")
+                            }
                         }
+                    } else {
+                        android.util.Log.d("RecommendedPlaceViewModel", 
+                            "⏸️ RANKING 상태 - 현재 사용자가 아직 확정하지 않음, 확인 생략")
                     }
                 }
             }
@@ -233,6 +300,7 @@ class RecommendedPlaceViewModel @Inject constructor(
 
     /**
      * 사용자별 순위 지정 저장
+     * ⭐ 책임 분리: 이 함수는 '저장'만 수행하고, '확인'은 리스너에게 완전히 위임
      */
     fun saveUserRankings(rankedPlaces: List<RankedPlace>) {
         val id = groupId ?: return
@@ -244,26 +312,50 @@ class RecommendedPlaceViewModel @Inject constructor(
                 android.util.Log.d("RecommendedPlaceViewModel", 
                     "💾 순위 저장 시작 - groupId: $id, 순위 개수: ${rankedPlaces.size}")
                 
-                // 1. 사용자별 순위 지정을 userRankings에 저장 (기존 로직 유지)
+                // 1. 사용자별 순위 지정을 userRankings에 저장
                 mapRepository.saveUserRankings(id, rankedPlaces)
                 
-                // 2. vote 문서의 rankedUsers 배열에 현재 사용자 추가 (⭐ 새로운 구조)
+                // 2. vote 문서의 rankedUsers 배열에 현재 사용자 추가
+                // ⚠️ 이 변경이 리스너를 트리거하여 자동으로 완료 여부를 확인함
                 groupRepository.addUserToRankedList(id, uid)
                 
+                // 3. UI 업데이트를 위한 상태 설정
+                _hasUserRanking.value = true
                 _rankingSaveSuccess.value = true
                 
-                android.util.Log.d("RecommendedPlaceViewModel", "✅ 순위 저장 완료 및 rankedUsers 업데이트")
-                
-                // 저장 완료 후 hasUserRanking을 true로 설정 (UI 업데이트용 observer 트리거)
-                _hasUserRanking.value = true
-                
-                // 저장 완료 후 충분한 지연을 두고 완료 여부 확인 (Firestore 서버 동기화 시간 확보)
-                kotlinx.coroutines.delay(1500)
-                
-                // ⚠️ 핵심: vote 문서의 rankedUsers 배열을 확인하여 모든 사용자 완료 여부 판단
                 android.util.Log.d("RecommendedPlaceViewModel", 
-                    "🔍 vote 문서 확인 - 모든 사용자 순위 지정 완료 여부 확인 시작")
-                checkAllUsersRankedWithRetry()
+                    "✅ 순위 저장 및 rankedUsers 업데이트 완료. 리스너가 상태를 확인할 것임.")
+                
+                // 4. 저장 후 즉시 vote 문서 상태 확인 (리스너가 즉시 반응하지 않을 수 있으므로)
+                // ⚠️ 단, 역할 분리를 유지하기 위해 간단한 확인만 수행
+                // ⚠️ 핵심: 현재 사용자가 확정한 상태(_hasUserRanking.value == true)에서만 확인
+                kotlinx.coroutines.delay(800) // Firestore 동기화 시간 확보
+                
+                // ⚠️ 핵심: 현재 사용자가 확정한 상태에서만 확인
+                // _hasUserRanking.value == true이어야 이 함수가 실행되는 것이 보장되지만,
+                // 혹시 모를 상황을 대비하여 명시적으로 확인
+                if (_hasUserRanking.value == true) {
+                    val currentVoteStatus = groupRepository.getVoteStatus(id)
+                    if (currentVoteStatus != null) {
+                        val allRanked = groupRepository.checkAllUsersRanked(id)
+                        android.util.Log.d("RecommendedPlaceViewModel", 
+                            "🔍 순위 저장 후 즉시 확인 - status: ${currentVoteStatus.status}, allRanked: $allRanked, _hasUserRanking: ${_hasUserRanking.value}")
+                        
+                        // ⚠️ 핵심: 모든 사용자가 완료했고, 현재 사용자도 확정한 경우에만 allUsersCompleted 설정
+                        if (allRanked && _hasUserRanking.value == true) {
+                            _allUsersCompleted.value = true
+                            android.util.Log.d("RecommendedPlaceViewModel", 
+                                "✅ 순위 저장 후 즉시 확인 - 모든 사용자 완료! allUsersCompleted = true")
+                        } else {
+                            android.util.Log.d("RecommendedPlaceViewModel", 
+                                "⏸️ 순위 저장 후 확인 - 아직 모든 사용자가 완료하지 않음 또는 현재 사용자가 확정하지 않음")
+                        }
+                    }
+                } else {
+                    android.util.Log.d("RecommendedPlaceViewModel", 
+                        "⏸️ 순위 저장 후 확인 생략 - 현재 사용자가 아직 확정하지 않음 (_hasUserRanking: ${_hasUserRanking.value})")
+                }
+                
             } catch (e: Exception) {
                 android.util.Log.e("RecommendedPlaceViewModel", 
                     "❌ 순위 저장 실패: ${e.message}", e)
@@ -333,68 +425,14 @@ class RecommendedPlaceViewModel @Inject constructor(
     }
 
     /**
-     * 모든 사용자가 순위 지정을 완료했는지 확인 (재시도 로직 포함)
-     * ⭐ 새로운 구조: vote 문서의 rankedUsers 배열을 확인하여 정확한 상태 판단
-     * Firestore 서버 동기화 지연을 고려하여 최대 5회까지 재시도
+     * ⚠️ 삭제됨: checkAllUsersRankedWithRetry()
+     * 
+     * 이 함수는 saveUserRankings()에서 호출되어 경쟁 조건을 발생시켰습니다.
+     * 이제 완료 여부 확인은 startListeningToVoteStatus() 리스너에서만 처리됩니다.
+     * 
+     * 역할 분리:
+     * - saveUserRankings(): 저장만 수행
+     * - startListeningToVoteStatus(): 감시만 수행
      */
-    private fun checkAllUsersRankedWithRetry(maxRetries: Int = 5) {
-        val id = groupId ?: return
-        
-        viewModelScope.launch {
-            var retryCount = 0
-            var allCompleted = false
-            
-            while (retryCount < maxRetries && !allCompleted) {
-                try {
-                    // ⭐ vote 문서의 rankedUsers 배열을 확인 (Single Source of Truth)
-                    val allRanked = groupRepository.checkAllUsersRanked(id)
-                    
-                    android.util.Log.d("RecommendedPlaceViewModel", 
-                        "🔍 vote 문서 확인 (시도 ${retryCount + 1}/$maxRetries) - groupId: $id, allRanked: $allRanked")
-                    
-                    if (allRanked) {
-                        allCompleted = true
-                        _allUsersCompleted.value = true
-                        android.util.Log.d("RecommendedPlaceViewModel", 
-                            "✅ 모든 사용자 순위 지정 완료! (시도 ${retryCount + 1}/$maxRetries)")
-                        return@launch
-                    } else {
-                        android.util.Log.d("RecommendedPlaceViewModel", 
-                            "⏸️ 아직 모든 사용자가 순위 지정을 완료하지 않음")
-                    }
-                    
-                    // 아직 완료되지 않았고 재시도 가능하면 잠시 대기 후 재시도
-                    if (retryCount < maxRetries - 1) {
-                        // 재시도 전에 지연 시간 증가 (지수 백오프)
-                        val delayMs = 800L * (retryCount + 1)
-                        android.util.Log.d("RecommendedPlaceViewModel", 
-                            "⏳ 모든 사용자 미완료 - ${delayMs}ms 후 재시도 (${retryCount + 1}/$maxRetries)")
-                        kotlinx.coroutines.delay(delayMs)
-                    }
-                    
-                    retryCount++
-                } catch (e: Exception) {
-                    android.util.Log.e("RecommendedPlaceViewModel", 
-                        "❌ 완료 상태 확인 실패 (시도 ${retryCount + 1}/$maxRetries): ${e.message}", e)
-                    
-                    if (retryCount < maxRetries - 1) {
-                        kotlinx.coroutines.delay(800L * (retryCount + 1))
-                        retryCount++
-                    } else {
-                        _error.value = "완료 상태 확인에 실패했습니다: ${e.message}"
-                        _allUsersCompleted.value = false
-                        return@launch
-                    }
-                }
-            }
-            
-            // 모든 재시도 후에도 완료되지 않음
-            if (!allCompleted) {
-                _allUsersCompleted.value = false
-                android.util.Log.d("RecommendedPlaceViewModel", 
-                    "⏸️ 아직 모든 사용자가 완료하지 않음 (최대 재시도 횟수 도달)")
-            }
-        }
-    }
 }
 

--- a/app/src/main/res/drawable/bg_button_primary_disabled.xml
+++ b/app/src/main/res/drawable/bg_button_primary_disabled.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <!-- 흐릿한 파란색 배경 -->
+    <solid android:color="#99B0D4FF" />
+    
+    <!-- 살짝 둥근 모서리 -->
+    <corners android:radius="12dp" />
+</shape>
+

--- a/app/src/main/res/drawable/bg_card_selected.xml
+++ b/app/src/main/res/drawable/bg_card_selected.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#DBEAFE" />
+    <corners android:radius="12dp" />
+    <stroke
+        android:width="2dp"
+        android:color="@color/brand_blue" />
+</shape>
+

--- a/app/src/main/res/layout/activity_midpoint.xml
+++ b/app/src/main/res/layout/activity_midpoint.xml
@@ -137,6 +137,7 @@
                             app:tint="@color/white" />
 
                         <TextView
+                            android:id="@+id/tvMidpointTitle"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="계산된 중간 지점"

--- a/app/src/main/res/layout/item_recommended_place.xml
+++ b/app/src/main/res/layout/item_recommended_place.xml
@@ -10,6 +10,7 @@
     android:foreground="?attr/selectableItemBackground">
 
     <LinearLayout
+        android:id="@+id/cardContainer"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@drawable/bg_card"


### PR DESCRIPTION
# 최종 투표 로직 구현 및 최종 투표된 장소 표시 기능

## 📋 개요

최종 투표로 확정된 장소를 중간값 계산 화면에 표시하고, 모든 사용자가 위치를 저장한 후 위치 변경을 제한하는 기능을 구현했습니다.

## ✨ 주요 변경사항

### 1. 최종 투표된 장소 표시 기능

#### 구현 내용
- **FinalVoteActivity → MidpointActivity 연동**
  - 최종 투표 완료 후 승리한 장소 정보를 Intent로 전달
  - 장소 ID, 이름, 주소, 좌표 정보 포함

- **ViewModel에 최종 모드 상태 추가**
  - `isFinalized: LiveData<Boolean>` 추가
  - `setFinalizedMode(place: NearbyPlace)` 함수 구현
  - 최종 모드와 중간 지점 계산 모드 분기 처리

- **UI 표시 개선**
  - 최종 확정된 장소를 빨간색 마커로 지도에 표시
  - 파란색 정보 박스에 최종 장소의 상호명과 주소 표시
  - 마커 클릭 시 "최종 확정된 장소" 정보창 표시

#### 관련 파일
- `app/src/main/java/com/moyeoyo/app/map/MapViewModel.kt`
  - `_isFinalized`, `isFinalized` 상태 추가
  - `setFinalizedMode()` 함수 구현
  - `onMapReady()` 함수에서 최종 모드 처리
  - `loadGroupMembersAndComputeDistances()` 함수 추가

- `app/src/main/java/com/moyeoyo/app/map/MidpointActivity.kt`
  - Intent에서 최종 장소 정보 수신 및 처리
  - `updateUIForMode()` 함수로 최종 모드/중간 지점 모드 분기
  - `updateMapMarkers()` 함수에서 최종 장소 마커 표시
  - 마커 클릭 리스너로 정보창 표시

- `app/src/main/java/com/moyeoyo/app/ui/place/FinalVoteActivity.kt`
  - 승리한 장소 결정 후 MidpointActivity로 Intent 전달

### 2. 위치 입력 잠금 기능

#### 구현 내용
- 모든 사용자가 위치를 저장하고 중간값 계산 화면으로 넘어간 후, 위치 변경 불가
- 중간값 계산 중 다른 사용자가 위치를 변경하는 것을 방지하여 일관성 유지

#### 관련 파일
- `app/src/main/java/com/moyeoyo/app/ui/location/LocationInputActivity.kt`
  - `isLocationLocked` 플래그 추가
  - `checkAllMembersInputted()` 함수에서 모든 사용자 위치 저장 시 잠금
  - `updateUIForLockedState()` 함수로 잠금 상태 UI 업데이트
  - 위치 입력 버튼 및 저장 버튼 비활성화

### 3. 성능 개선

#### 구현 내용
- 멤버 로드 및 거리 계산 중복 호출 방지
- `isLoadingMembers` 플래그로 동시 호출 방지
- `setFinalizedMode`와 `onMapReady`의 중복 호출 최적화

#### 관련 파일
- `app/src/main/java/com/moyeoyo/app/map/MapViewModel.kt`
  - `isLoadingMembers` 플래그 추가
  - `loadGroupMembersAndComputeDistances()` 함수에 중복 호출 방지 로직 추가
  - `setFinalizedMode()`에서 멤버 로드 제거 (onMapReady에서만 처리)

## 🔧 기술적 세부사항

### MVVM 패턴 개선
- Activity에서 상태 관리 제거 (`pendingWinningPlace`, `hasWinningPlace` 등)
- ViewModel을 Single Source of Truth로 통합
- `isFinalized` 상태로 최종 모드/중간 지점 모드 명확히 분리

### 상태 관리 흐름
1. **최종 투표 완료**
   - FinalVoteActivity에서 승리한 장소 결정
   - Intent로 MidpointActivity에 장소 정보 전달

2. **MidpointActivity 초기화**
   - Intent에서 최종 장소 정보 확인
   - `viewModel.setFinalizedMode()` 호출
   - `isFinalized = true` 설정

3. **지도 준비 완료**
   - `onMapReady()` 호출
   - 멤버 로드 및 거리 계산 (필요 시)

4. **UI 업데이트**
   - `observe()`에서 `isFinalized` 상태 확인
   - 최종 모드: 최종 장소 정보 표시
   - 중간 지점 모드: 중간 지점 정보 표시

## 🐛 버그 수정

- 최종 장소 정보가 파란색 박스에 표시되지 않던 문제 해결
- 빨간색 마커 클릭 시 정보창이 표시되지 않던 문제 해결
- 중복 호출로 인한 성능 저하 문제 해결

## 📸 UI 변경사항

- 최종 확정된 장소: 빨간색 마커 + "최종 확정된 약속 장소" 제목
- 중간 지점: 파란색 마커 + "계산된 중간 지점" 제목
- 위치 입력 잠금: 모든 사용자 위치 저장 후 버튼 비활성화

## ✅ 테스트 결과

- ✅ 최종 투표 완료 후 MidpointActivity에서 최종 장소 정상 표시
- ✅ 빨간색 마커 클릭 시 정보창 정상 표시
- ✅ 모든 사용자 위치 저장 후 위치 변경 불가 확인
- ✅ 중복 호출 방지로 성능 개선 확인

## 📝 참고사항

- 최종 모드와 중간 지점 모드는 `isFinalized` 상태로 명확히 분리
- 위치 잠금은 모든 사용자가 위치를 저장한 시점에 활성화
- 중복 호출 방지를 통해 Firestore 쿼리 및 API 호출 최적화

