### PR TITLE
Time/voting

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,6 +43,9 @@
 
         <activity android:name=".ui.place.RecommendedPlaceActivity" />
         <activity android:name=".ui.place.FinalVoteActivity" />
+        
+        <activity android:name=".ui.time.TimeVoteActivity" />
+        <activity android:name=".ui.time.FinalTimeVoteActivity" />
 
         <activity android:name=".ui.notification.NotificationActivity" />
 

--- a/app/src/main/java/com/moyeoyo/app/data/repository/GroupRepository.kt
+++ b/app/src/main/java/com/moyeoyo/app/data/repository/GroupRepository.kt
@@ -8,14 +8,7 @@ import com.google.firebase.firestore.GeoPoint
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FieldPath
-import com.google.firebase.firestore.ListenerRegistration
-import com.google.firebase.firestore.Source
 import com.moyeoyo.app.data.model.Group
-import com.moyeoyo.app.data.model.Vote
-import com.moyeoyo.app.data.model.FinalCandidateData
-import kotlinx.coroutines.channels.awaitClose
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -59,7 +52,7 @@ class GroupRepository @Inject constructor(
             groupName = groupName,
             hostUid = hostUid,
             memberUids = allMemberUids, // ⭐ 멤버 목록 포함
-            status = "VOTING"
+            status = "GROUP_CREATED" // 초기 상태: 그룹 생성 완료
         )
 
         return try {
@@ -76,18 +69,7 @@ class GroupRepository @Inject constructor(
                     "timestamp" to Timestamp.now()
                 )).await()
 
-            // 2. vote 하위 문서 생성 (투표 상태 관리용)
-            groupsCollection.document(groupId)
-                .collection("vote")
-                .document("vote")
-                .set(Vote(
-                    status = "RANKING",
-                    rankedUsers = emptyList(),
-                    finalCandidates = emptyList(),
-                    finalVotedUsers = emptyList()
-                )).await()
-
-            // 3. 모든 멤버의 users 문서에 groupId를 groups 배열에 추가 (일괄 쓰기 사용)
+            // 2. 모든 멤버의 users 문서에 groupId를 groups 배열에 추가 (일괄 쓰기 사용)
             val batch = db.batch()
             allMemberUids.forEach { uid ->
                 val userRef = usersCollection.document(uid)
@@ -95,7 +77,7 @@ class GroupRepository @Inject constructor(
             }
             batch.commit().await()
 
-            Log.d("GroupRepository", "Group created successfully with ID: $groupId, Members: ${allMemberUids.size}, Vote document created")
+            Log.d("GroupRepository", "Group created successfully with ID: $groupId, Members: ${allMemberUids.size}")
             groupId
         } catch (e: Exception) {
             Log.e("GroupRepository", "Group creation with members failed: ${e.message}", e)
@@ -325,6 +307,7 @@ class GroupRepository @Inject constructor(
             deleteCollection(groupRef.collection("inputLocations"))
             deleteCollection(groupRef.collection("placeCandidates"))
             deleteCollection(groupRef.collection("timeCandidates"))
+            deleteCollection(groupRef.collection("vote"))
 
             // 3. 그룹 문서 삭제
             groupRef.delete().await()
@@ -361,306 +344,55 @@ class GroupRepository @Inject constructor(
         batch.commit().await()
     }
 
-    // =========================
-    // Firestore: vote (투표 상태 관리)
-    // =========================
-
     /**
-     * 1차 순위 투표 완료한 사용자를 rankedUsers 배열에 추가
+     * 그룹 상태 업데이트
+     * @param groupId 그룹 ID
+     * @param status 새로운 상태 (GROUP_CREATED, TIME_VOTE_REQUIRED, TIME_FINALIZING, LOCATION_INPUT_REQUIRED, LOCATION_DONE, PLACE_RANKING, FINAL_PLACE_VOTE, FINALIZED, REMINDER_SCHEDULED)
      */
-    suspend fun addUserToRankedList(groupId: String, uid: String) {
-        try {
-            val voteRef = groupsCollection.document(groupId)
-                .collection("vote")
-                .document("vote")
-            
-            voteRef.update("rankedUsers", FieldValue.arrayUnion(uid)).await()
-            Log.d(TAG, "User $uid added to rankedUsers for group $groupId")
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to add user to rankedUsers: ${e.message}", e)
-            throw e
-        }
-    }
-
-    /**
-     * 모든 사용자가 1차 순위 투표를 완료했는지 확인
-     * @return true if all members have completed ranking, false otherwise
-     */
-    suspend fun checkAllUsersRanked(groupId: String): Boolean {
+    suspend fun updateGroupStatus(groupId: String, status: String): Boolean {
         return try {
-            // 그룹 멤버 수 확인
-            val group = getGroupById(groupId) ?: return false
-            val totalMembers = group.memberUids.size
-
-            // vote 문서에서 rankedUsers 확인
-            val voteRef = groupsCollection.document(groupId)
-                .collection("vote")
-                .document("vote")
-            val voteSnapshot = voteRef.get().await()
+            groupsCollection.document(groupId)
+                .update("status", status)
+                .await()
             
-            @Suppress("UNCHECKED_CAST")
-            val rankedUsers = voteSnapshot.get("rankedUsers") as? List<String> ?: emptyList()
-            
-            val allRanked = rankedUsers.size == totalMembers && 
-                           group.memberUids.all { it in rankedUsers }
-            
-            Log.d(TAG, "checkAllUsersRanked - groupId: $groupId, totalMembers: $totalMembers, rankedUsers: ${rankedUsers.size}, allRanked: $allRanked")
-            
-            allRanked
+            Log.d(TAG, "✅ 그룹 상태 업데이트: groupId=$groupId, status=$status")
+            true
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to check all users ranked: ${e.message}", e)
+            Log.e(TAG, "❌ 그룹 상태 업데이트 실패: ${e.message}", e)
             false
         }
     }
 
     /**
-     * 투표 상태 업데이트
+     * 최종 시간 확정
+     * @param groupId 그룹 ID
+     * @param date 날짜 (yyyy-MM-dd)
+     * @param time 시간 (HH:00)
      */
-    suspend fun updateVoteStatus(groupId: String, status: String) {
-        try {
-            val voteRef = groupsCollection.document(groupId)
-                .collection("vote")
-                .document("vote")
-            
-            voteRef.update("status", status).await()
-            Log.d(TAG, "Vote status updated to $status for group $groupId")
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to update vote status: ${e.message}", e)
-            throw e
-        }
-    }
-
-    /**
-     * 최종 후보 3개 업데이트 및 상태를 FINAL_VOTING으로 변경
-     */
-    suspend fun updateFinalCandidates(groupId: String, finalCandidates: List<FinalCandidateData>) {
-        try {
-            val voteRef = groupsCollection.document(groupId)
-                .collection("vote")
-                .document("vote")
-            
-            // finalCandidates를 Firestore에 저장할 수 있는 형태로 변환
-            val candidatesData = finalCandidates.map { candidate ->
-                mapOf(
-                    "placeId" to candidate.placeId,
-                    "name" to candidate.name,
-                    "latLng" to candidate.latLng,
-                    "totalScore" to candidate.totalScore,
-                    "categories" to candidate.categories,
-                    "rating" to (candidate.rating ?: ""),
-                    "address" to (candidate.address ?: "")
-                )
-            }
-            
-            voteRef.update(
-                "finalCandidates", candidatesData,
-                "status", "FINAL_VOTING"
-            ).await()
-            
-            Log.d(TAG, "Final candidates updated (${finalCandidates.size} items) and status changed to FINAL_VOTING for group $groupId")
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to update final candidates: ${e.message}", e)
-            throw e
-        }
-    }
-
-    /**
-     * 최종 투표 완료한 사용자를 finalVotedUsers 배열에 추가
-     */
-    suspend fun addUserToFinalVotedList(groupId: String, uid: String) {
-        try {
-            val voteRef = groupsCollection.document(groupId)
-                .collection("vote")
-                .document("vote")
-            
-            voteRef.update("finalVotedUsers", FieldValue.arrayUnion(uid)).await()
-            Log.d(TAG, "User $uid added to finalVotedUsers for group $groupId")
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to add user to finalVotedUsers: ${e.message}", e)
-            throw e
-        }
-    }
-
-    /**
-     * 모든 사용자가 최종 투표를 완료했는지 확인
-     */
-    suspend fun checkAllUsersFinalVoted(groupId: String): Boolean {
+    suspend fun setFinalTime(groupId: String, date: String, time: String): Boolean {
         return try {
-            val group = getGroupById(groupId) ?: return false
-            val totalMembers = group.memberUids.size
-
-            val voteRef = groupsCollection.document(groupId)
-                .collection("vote")
-                .document("vote")
-            // ⚠️ Source.SERVER 추가하여 서버 데이터만 확인 (캐시 문제 방지)
-            val voteSnapshot = voteRef.get(Source.SERVER).await()
+            // Timestamp 생성 (날짜 + 시간)
+            val dateTime = java.text.SimpleDateFormat("yyyy-MM-dd HH:mm", java.util.Locale.getDefault())
+                .parse("$date $time")
             
-            @Suppress("UNCHECKED_CAST")
-            val finalVotedUsers = voteSnapshot.get("finalVotedUsers") as? List<String> ?: emptyList()
-            
-            val allVoted = finalVotedUsers.size == totalMembers && 
-                          group.memberUids.all { it in finalVotedUsers }
-            
-            Log.d(TAG, "checkAllUsersFinalVoted - groupId: $groupId, totalMembers: $totalMembers, finalVotedUsers: ${finalVotedUsers.size}, allVoted: $allVoted")
-            
-            allVoted
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to check all users final voted: ${e.message}", e)
-            false
-        }
-    }
-
-    /**
-     * 투표 상태 조회
-     */
-    suspend fun getVoteStatus(groupId: String): Vote? {
-        return try {
-            val voteRef = groupsCollection.document(groupId)
-                .collection("vote")
-                .document("vote")
-            val snapshot = voteRef.get().await()
-            
-            if (snapshot.exists()) {
-                convertSnapshotToVote(snapshot)
+            val timestamp = if (dateTime != null) {
+                Timestamp(dateTime)
             } else {
-                Log.w(TAG, "Vote document not found for group $groupId")
                 null
             }
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to get vote status: ${e.message}", e)
-            null
-        }
-    }
 
-    /**
-     * Firestore 스냅샷을 Vote 객체로 변환
-     */
-    private fun convertSnapshotToVote(snapshot: com.google.firebase.firestore.DocumentSnapshot): Vote {
-        val status = snapshot.get("status") as? String ?: "RANKING"
-        @Suppress("UNCHECKED_CAST")
-        val rankedUsers = (snapshot.get("rankedUsers") as? List<String>) ?: emptyList()
-        @Suppress("UNCHECKED_CAST")
-        val finalVotedUsers = (snapshot.get("finalVotedUsers") as? List<String>) ?: emptyList()
-        val winningPlaceId = snapshot.get("winningPlaceId") as? String
-        val winningPlaceName = snapshot.get("winningPlaceName") as? String
-        
-        // finalCandidates를 Map에서 FinalCandidateData로 변환
-        @Suppress("UNCHECKED_CAST")
-        val finalCandidatesData = (snapshot.get("finalCandidates") as? List<Map<String, Any>>)?.mapNotNull { map ->
-            try {
-                val placeId = map["placeId"] as? String ?: return@mapNotNull null
-                val name = map["name"] as? String ?: return@mapNotNull null
-                val latLng = when (val geo = map["latLng"]) {
-                    is GeoPoint -> geo
-                    is Map<*, *> -> {
-                        val lat = (geo["lat"] as? Number)?.toDouble() ?: (geo["latitude"] as? Number)?.toDouble()
-                        val lng = (geo["lng"] as? Number)?.toDouble() ?: (geo["longitude"] as? Number)?.toDouble()
-                        if (lat != null && lng != null) GeoPoint(lat, lng) else return@mapNotNull null
-                    }
-                    else -> return@mapNotNull null
-                }
-                val totalScore = (map["totalScore"] as? Number)?.toInt() ?: return@mapNotNull null
-                @Suppress("UNCHECKED_CAST")
-                val categories = (map["categories"] as? List<String>) ?: emptyList()
-                val rating = when (val ratingValue = map["rating"]) {
-                    is Number -> ratingValue.toDouble()
-                    is String -> if (ratingValue.isNotEmpty()) ratingValue.toDoubleOrNull() else null
-                    else -> null
-                }
-                val address = map["address"] as? String
-                
-                FinalCandidateData(
-                    placeId = placeId,
-                    name = name,
-                    latLng = latLng,
-                    totalScore = totalScore,
-                    categories = categories,
-                    rating = rating,
-                    address = address
+            groupsCollection.document(groupId)
+                .update(
+                    "confirmedTime", timestamp,
+                    "status", "LOCATION_INPUT_REQUIRED"
                 )
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to convert finalCandidate data: ${e.message}", e)
-                null
-            }
-        } ?: emptyList()
-        
-        return Vote(
-            status = status,
-            rankedUsers = rankedUsers,
-            finalCandidates = finalCandidatesData,
-            finalVotedUsers = finalVotedUsers,
-            winningPlaceId = winningPlaceId,
-            winningPlaceName = winningPlaceName
-        )
-    }
-
-    /**
-     * 투표 상태 실시간 리스너 (Flow로 반환)
-     */
-    fun listenToVoteStatus(groupId: String): Flow<Vote?> = callbackFlow {
-        val voteRef = groupsCollection.document(groupId)
-            .collection("vote")
-            .document("vote")
-        
-        val listener = voteRef.addSnapshotListener { snapshot, error ->
-            if (error != null) {
-                Log.e(TAG, "Error listening to vote status: ${error.message}", error)
-                trySend(null)
-                return@addSnapshotListener
-            }
+                .await()
             
-            val vote = snapshot?.let { convertSnapshotToVote(it) }
-            trySend(vote)
-        }
-        
-        awaitClose { listener.remove() }
-    }
-
-    /**
-     * 승리한 장소로 투표 상태 완료 처리
-     */
-    suspend fun setWinningPlace(groupId: String, placeId: String, placeName: String) {
-        try {
-            val voteRef = groupsCollection.document(groupId)
-                .collection("vote")
-                .document("vote")
-            
-            voteRef.update(
-                "winningPlaceId", placeId,
-                "winningPlaceName", placeName,
-                "status", "FINISHED"
-            ).await()
-            
-            Log.d(TAG, "Winning place set: $placeName ($placeId) for group $groupId, status changed to FINISHED")
+            Log.d(TAG, "✅ 최종 시간 확정: groupId=$groupId, date=$date, time=$time")
+            true
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to set winning place: ${e.message}", e)
-            throw e
-        }
-    }
-    
-    /**
-     * 투표 상태를 RANKING으로 초기화 (이전 테스트 데이터 정리용)
-     * ⚠️ 주의: 이 함수는 테스트 중에만 사용하거나, 새로운 투표 세션을 시작할 때 사용해야 합니다.
-     */
-    suspend fun resetVoteStatus(groupId: String) {
-        try {
-            val voteRef = groupsCollection.document(groupId)
-                .collection("vote")
-                .document("vote")
-            
-            voteRef.update(
-                "status", "RANKING",
-                "rankedUsers", emptyList<String>(),
-                "finalCandidates", emptyList<Map<String, Any>>(),
-                "finalVotedUsers", emptyList<String>(),
-                "winningPlaceId", null,
-                "winningPlaceName", null
-            ).await()
-            
-            Log.d(TAG, "Vote status reset to RANKING for group $groupId")
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to reset vote status: ${e.message}", e)
-            throw e
+            Log.e(TAG, "❌ 최종 시간 확정 실패: ${e.message}", e)
+            false
         }
     }
 }

--- a/app/src/main/java/com/moyeoyo/app/data/repository/GroupRepository.kt
+++ b/app/src/main/java/com/moyeoyo/app/data/repository/GroupRepository.kt
@@ -8,7 +8,14 @@ import com.google.firebase.firestore.GeoPoint
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FieldPath
+import com.google.firebase.firestore.ListenerRegistration
+import com.google.firebase.firestore.Source
 import com.moyeoyo.app.data.model.Group
+import com.moyeoyo.app.data.model.Vote
+import com.moyeoyo.app.data.model.FinalCandidateData
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -52,7 +59,7 @@ class GroupRepository @Inject constructor(
             groupName = groupName,
             hostUid = hostUid,
             memberUids = allMemberUids, // ⭐ 멤버 목록 포함
-            status = "GROUP_CREATED" // 초기 상태: 그룹 생성 완료
+            status = "VOTING"
         )
 
         return try {
@@ -69,7 +76,18 @@ class GroupRepository @Inject constructor(
                     "timestamp" to Timestamp.now()
                 )).await()
 
-            // 2. 모든 멤버의 users 문서에 groupId를 groups 배열에 추가 (일괄 쓰기 사용)
+            // 2. vote 하위 문서 생성 (투표 상태 관리용)
+            groupsCollection.document(groupId)
+                .collection("vote")
+                .document("vote")
+                .set(Vote(
+                    status = "RANKING",
+                    rankedUsers = emptyList(),
+                    finalCandidates = emptyList(),
+                    finalVotedUsers = emptyList()
+                )).await()
+
+            // 3. 모든 멤버의 users 문서에 groupId를 groups 배열에 추가 (일괄 쓰기 사용)
             val batch = db.batch()
             allMemberUids.forEach { uid ->
                 val userRef = usersCollection.document(uid)
@@ -77,7 +95,7 @@ class GroupRepository @Inject constructor(
             }
             batch.commit().await()
 
-            Log.d("GroupRepository", "Group created successfully with ID: $groupId, Members: ${allMemberUids.size}")
+            Log.d("GroupRepository", "Group created successfully with ID: $groupId, Members: ${allMemberUids.size}, Vote document created")
             groupId
         } catch (e: Exception) {
             Log.e("GroupRepository", "Group creation with members failed: ${e.message}", e)
@@ -307,7 +325,6 @@ class GroupRepository @Inject constructor(
             deleteCollection(groupRef.collection("inputLocations"))
             deleteCollection(groupRef.collection("placeCandidates"))
             deleteCollection(groupRef.collection("timeCandidates"))
-            deleteCollection(groupRef.collection("vote"))
 
             // 3. 그룹 문서 삭제
             groupRef.delete().await()
@@ -344,55 +361,306 @@ class GroupRepository @Inject constructor(
         batch.commit().await()
     }
 
+    // =========================
+    // Firestore: vote (투표 상태 관리)
+    // =========================
+
     /**
-     * 그룹 상태 업데이트
-     * @param groupId 그룹 ID
-     * @param status 새로운 상태 (GROUP_CREATED, TIME_VOTE_REQUIRED, TIME_FINALIZING, LOCATION_INPUT_REQUIRED, LOCATION_DONE, PLACE_RANKING, FINAL_PLACE_VOTE, FINALIZED, REMINDER_SCHEDULED)
+     * 1차 순위 투표 완료한 사용자를 rankedUsers 배열에 추가
      */
-    suspend fun updateGroupStatus(groupId: String, status: String): Boolean {
-        return try {
-            groupsCollection.document(groupId)
-                .update("status", status)
-                .await()
-            
-            Log.d(TAG, "✅ 그룹 상태 업데이트: groupId=$groupId, status=$status")
-            true
+    suspend fun addUserToRankedList(groupId: String, uid: String) {
+        try {
+            val voteRef = groupsCollection.document(groupId)
+                .collection("vote")
+                .document("vote")
+
+            voteRef.update("rankedUsers", FieldValue.arrayUnion(uid)).await()
+            Log.d(TAG, "User $uid added to rankedUsers for group $groupId")
         } catch (e: Exception) {
-            Log.e(TAG, "❌ 그룹 상태 업데이트 실패: ${e.message}", e)
+            Log.e(TAG, "Failed to add user to rankedUsers: ${e.message}", e)
+            throw e
+        }
+    }
+
+    /**
+     * 모든 사용자가 1차 순위 투표를 완료했는지 확인
+     * @return true if all members have completed ranking, false otherwise
+     */
+    suspend fun checkAllUsersRanked(groupId: String): Boolean {
+        return try {
+            // 그룹 멤버 수 확인
+            val group = getGroupById(groupId) ?: return false
+            val totalMembers = group.memberUids.size
+
+            // vote 문서에서 rankedUsers 확인
+            val voteRef = groupsCollection.document(groupId)
+                .collection("vote")
+                .document("vote")
+            val voteSnapshot = voteRef.get().await()
+
+            @Suppress("UNCHECKED_CAST")
+            val rankedUsers = voteSnapshot.get("rankedUsers") as? List<String> ?: emptyList()
+
+            val allRanked = rankedUsers.size == totalMembers &&
+                    group.memberUids.all { it in rankedUsers }
+
+            Log.d(TAG, "checkAllUsersRanked - groupId: $groupId, totalMembers: $totalMembers, rankedUsers: ${rankedUsers.size}, allRanked: $allRanked")
+
+            allRanked
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to check all users ranked: ${e.message}", e)
             false
         }
     }
 
     /**
-     * 최종 시간 확정
-     * @param groupId 그룹 ID
-     * @param date 날짜 (yyyy-MM-dd)
-     * @param time 시간 (HH:00)
+     * 투표 상태 업데이트
      */
-    suspend fun setFinalTime(groupId: String, date: String, time: String): Boolean {
-        return try {
-            // Timestamp 생성 (날짜 + 시간)
-            val dateTime = java.text.SimpleDateFormat("yyyy-MM-dd HH:mm", java.util.Locale.getDefault())
-                .parse("$date $time")
-            
-            val timestamp = if (dateTime != null) {
-                Timestamp(dateTime)
-            } else {
-                null
+    suspend fun updateVoteStatus(groupId: String, status: String) {
+        try {
+            val voteRef = groupsCollection.document(groupId)
+                .collection("vote")
+                .document("vote")
+
+            voteRef.update("status", status).await()
+            Log.d(TAG, "Vote status updated to $status for group $groupId")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to update vote status: ${e.message}", e)
+            throw e
+        }
+    }
+
+    /**
+     * 최종 후보 3개 업데이트 및 상태를 FINAL_VOTING으로 변경
+     */
+    suspend fun updateFinalCandidates(groupId: String, finalCandidates: List<FinalCandidateData>) {
+        try {
+            val voteRef = groupsCollection.document(groupId)
+                .collection("vote")
+                .document("vote")
+
+            // finalCandidates를 Firestore에 저장할 수 있는 형태로 변환
+            val candidatesData = finalCandidates.map { candidate ->
+                mapOf(
+                    "placeId" to candidate.placeId,
+                    "name" to candidate.name,
+                    "latLng" to candidate.latLng,
+                    "totalScore" to candidate.totalScore,
+                    "categories" to candidate.categories,
+                    "rating" to (candidate.rating ?: ""),
+                    "address" to (candidate.address ?: "")
+                )
             }
 
-            groupsCollection.document(groupId)
-                .update(
-                    "confirmedTime", timestamp,
-                    "status", "LOCATION_INPUT_REQUIRED"
-                )
-                .await()
-            
-            Log.d(TAG, "✅ 최종 시간 확정: groupId=$groupId, date=$date, time=$time")
-            true
+            voteRef.update(
+                "finalCandidates", candidatesData,
+                "status", "FINAL_VOTING"
+            ).await()
+
+            Log.d(TAG, "Final candidates updated (${finalCandidates.size} items) and status changed to FINAL_VOTING for group $groupId")
         } catch (e: Exception) {
-            Log.e(TAG, "❌ 최종 시간 확정 실패: ${e.message}", e)
+            Log.e(TAG, "Failed to update final candidates: ${e.message}", e)
+            throw e
+        }
+    }
+
+    /**
+     * 최종 투표 완료한 사용자를 finalVotedUsers 배열에 추가
+     */
+    suspend fun addUserToFinalVotedList(groupId: String, uid: String) {
+        try {
+            val voteRef = groupsCollection.document(groupId)
+                .collection("vote")
+                .document("vote")
+
+            voteRef.update("finalVotedUsers", FieldValue.arrayUnion(uid)).await()
+            Log.d(TAG, "User $uid added to finalVotedUsers for group $groupId")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to add user to finalVotedUsers: ${e.message}", e)
+            throw e
+        }
+    }
+
+    /**
+     * 모든 사용자가 최종 투표를 완료했는지 확인
+     */
+    suspend fun checkAllUsersFinalVoted(groupId: String): Boolean {
+        return try {
+            val group = getGroupById(groupId) ?: return false
+            val totalMembers = group.memberUids.size
+
+            val voteRef = groupsCollection.document(groupId)
+                .collection("vote")
+                .document("vote")
+            // ⚠️ Source.SERVER 추가하여 서버 데이터만 확인 (캐시 문제 방지)
+            val voteSnapshot = voteRef.get(Source.SERVER).await()
+
+            @Suppress("UNCHECKED_CAST")
+            val finalVotedUsers = voteSnapshot.get("finalVotedUsers") as? List<String> ?: emptyList()
+
+            val allVoted = finalVotedUsers.size == totalMembers &&
+                    group.memberUids.all { it in finalVotedUsers }
+
+            Log.d(TAG, "checkAllUsersFinalVoted - groupId: $groupId, totalMembers: $totalMembers, finalVotedUsers: ${finalVotedUsers.size}, allVoted: $allVoted")
+
+            allVoted
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to check all users final voted: ${e.message}", e)
             false
+        }
+    }
+
+    /**
+     * 투표 상태 조회
+     */
+    suspend fun getVoteStatus(groupId: String): Vote? {
+        return try {
+            val voteRef = groupsCollection.document(groupId)
+                .collection("vote")
+                .document("vote")
+            val snapshot = voteRef.get().await()
+
+            if (snapshot.exists()) {
+                convertSnapshotToVote(snapshot)
+            } else {
+                Log.w(TAG, "Vote document not found for group $groupId")
+                null
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to get vote status: ${e.message}", e)
+            null
+        }
+    }
+
+    /**
+     * Firestore 스냅샷을 Vote 객체로 변환
+     */
+    private fun convertSnapshotToVote(snapshot: com.google.firebase.firestore.DocumentSnapshot): Vote {
+        val status = snapshot.get("status") as? String ?: "RANKING"
+        @Suppress("UNCHECKED_CAST")
+        val rankedUsers = (snapshot.get("rankedUsers") as? List<String>) ?: emptyList()
+        @Suppress("UNCHECKED_CAST")
+        val finalVotedUsers = (snapshot.get("finalVotedUsers") as? List<String>) ?: emptyList()
+        val winningPlaceId = snapshot.get("winningPlaceId") as? String
+        val winningPlaceName = snapshot.get("winningPlaceName") as? String
+
+        // finalCandidates를 Map에서 FinalCandidateData로 변환
+        @Suppress("UNCHECKED_CAST")
+        val finalCandidatesData = (snapshot.get("finalCandidates") as? List<Map<String, Any>>)?.mapNotNull { map ->
+            try {
+                val placeId = map["placeId"] as? String ?: return@mapNotNull null
+                val name = map["name"] as? String ?: return@mapNotNull null
+                val latLng = when (val geo = map["latLng"]) {
+                    is GeoPoint -> geo
+                    is Map<*, *> -> {
+                        val lat = (geo["lat"] as? Number)?.toDouble() ?: (geo["latitude"] as? Number)?.toDouble()
+                        val lng = (geo["lng"] as? Number)?.toDouble() ?: (geo["longitude"] as? Number)?.toDouble()
+                        if (lat != null && lng != null) GeoPoint(lat, lng) else return@mapNotNull null
+                    }
+                    else -> return@mapNotNull null
+                }
+                val totalScore = (map["totalScore"] as? Number)?.toInt() ?: return@mapNotNull null
+                @Suppress("UNCHECKED_CAST")
+                val categories = (map["categories"] as? List<String>) ?: emptyList()
+                val rating = when (val ratingValue = map["rating"]) {
+                    is Number -> ratingValue.toDouble()
+                    is String -> if (ratingValue.isNotEmpty()) ratingValue.toDoubleOrNull() else null
+                    else -> null
+                }
+                val address = map["address"] as? String
+
+                FinalCandidateData(
+                    placeId = placeId,
+                    name = name,
+                    latLng = latLng,
+                    totalScore = totalScore,
+                    categories = categories,
+                    rating = rating,
+                    address = address
+                )
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to convert finalCandidate data: ${e.message}", e)
+                null
+            }
+        } ?: emptyList()
+
+        return Vote(
+            status = status,
+            rankedUsers = rankedUsers,
+            finalCandidates = finalCandidatesData,
+            finalVotedUsers = finalVotedUsers,
+            winningPlaceId = winningPlaceId,
+            winningPlaceName = winningPlaceName
+        )
+    }
+
+    /**
+     * 투표 상태 실시간 리스너 (Flow로 반환)
+     */
+    fun listenToVoteStatus(groupId: String): Flow<Vote?> = callbackFlow {
+        val voteRef = groupsCollection.document(groupId)
+            .collection("vote")
+            .document("vote")
+
+        val listener = voteRef.addSnapshotListener { snapshot, error ->
+            if (error != null) {
+                Log.e(TAG, "Error listening to vote status: ${error.message}", error)
+                trySend(null)
+                return@addSnapshotListener
+            }
+
+            val vote = snapshot?.let { convertSnapshotToVote(it) }
+            trySend(vote)
+        }
+
+        awaitClose { listener.remove() }
+    }
+
+    /**
+     * 승리한 장소로 투표 상태 완료 처리
+     */
+    suspend fun setWinningPlace(groupId: String, placeId: String, placeName: String) {
+        try {
+            val voteRef = groupsCollection.document(groupId)
+                .collection("vote")
+                .document("vote")
+
+            voteRef.update(
+                "winningPlaceId", placeId,
+                "winningPlaceName", placeName,
+                "status", "FINISHED"
+            ).await()
+
+            Log.d(TAG, "Winning place set: $placeName ($placeId) for group $groupId, status changed to FINISHED")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to set winning place: ${e.message}", e)
+            throw e
+        }
+    }
+
+    /**
+     * 투표 상태를 RANKING으로 초기화 (이전 테스트 데이터 정리용)
+     * ⚠️ 주의: 이 함수는 테스트 중에만 사용하거나, 새로운 투표 세션을 시작할 때 사용해야 합니다.
+     */
+    suspend fun resetVoteStatus(groupId: String) {
+        try {
+            val voteRef = groupsCollection.document(groupId)
+                .collection("vote")
+                .document("vote")
+
+            voteRef.update(
+                "status", "RANKING",
+                "rankedUsers", emptyList<String>(),
+                "finalCandidates", emptyList<Map<String, Any>>(),
+                "finalVotedUsers", emptyList<String>(),
+                "winningPlaceId", null,
+                "winningPlaceName", null
+            ).await()
+
+            Log.d(TAG, "Vote status reset to RANKING for group $groupId")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to reset vote status: ${e.message}", e)
+            throw e
         }
     }
 }

--- a/app/src/main/java/com/moyeoyo/app/data/repository/TimeVoteRepository.kt
+++ b/app/src/main/java/com/moyeoyo/app/data/repository/TimeVoteRepository.kt
@@ -1,0 +1,339 @@
+package com.moyeoyo.app.data.repository
+
+import android.util.Log
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.FieldValue
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * 시간 투표 데이터를 관리하는 Repository
+ * Firestore 구조: groups/{groupId}/timeVotes/{date}/times/{time}/voters: [uid1, uid2, ...]
+ */
+@Singleton
+class TimeVoteRepository @Inject constructor(
+    private val db: FirebaseFirestore
+) {
+    private val TAG = "TimeVoteRepository"
+
+    /**
+     * 특정 날짜의 시간에 투표
+     * @param groupId 그룹 ID
+     * @param date 날짜 (yyyy-MM-dd 형식)
+     * @param time 시간 (HH:00 형식, 예: "14:00")
+     * @param uid 투표한 사용자 UID
+     */
+    suspend fun voteTime(groupId: String, date: String, time: String, uid: String) {
+        try {
+            val timeVoteRef = db.collection("groups")
+                .document(groupId)
+                .collection("timeVotes")
+                .document(date)
+                .collection("times")
+                .document(time)
+
+            timeVoteRef.set(
+                mapOf("voters" to FieldValue.arrayUnion(uid)),
+                com.google.firebase.firestore.SetOptions.merge()
+            ).await()
+
+            Log.d(TAG, "✅ 시간 투표 저장: groupId=$groupId, date=$date, time=$time, uid=$uid")
+        } catch (e: Exception) {
+            Log.e(TAG, "❌ 시간 투표 저장 실패: ${e.message}", e)
+            throw e
+        }
+    }
+
+    /**
+     * 특정 날짜의 시간 투표 취소
+     */
+    suspend fun unvoteTime(groupId: String, date: String, time: String, uid: String) {
+        try {
+            val timeVoteRef = db.collection("groups")
+                .document(groupId)
+                .collection("timeVotes")
+                .document(date)
+                .collection("times")
+                .document(time)
+
+            timeVoteRef.update("voters", FieldValue.arrayRemove(uid)).await()
+            Log.d(TAG, "✅ 시간 투표 취소: groupId=$groupId, date=$date, time=$time, uid=$uid")
+        } catch (e: Exception) {
+            Log.e(TAG, "❌ 시간 투표 취소 실패: ${e.message}", e)
+            throw e
+        }
+    }
+
+    /**
+     * 특정 날짜의 모든 시간 투표를 실시간으로 관찰
+     * @return Map<String, List<String>> - 시간(키)과 투표한 사용자 UID 리스트(값)
+     */
+    fun observeVotes(groupId: String, date: String): Flow<Map<String, List<String>>> = callbackFlow {
+        val timeVotesRef = db.collection("groups")
+            .document(groupId)
+            .collection("timeVotes")
+            .document(date)
+            .collection("times")
+
+        val listenerRegistration = timeVotesRef.addSnapshotListener { snapshot, error ->
+            if (error != null) {
+                Log.e(TAG, "시간 투표 리스너 오류: ${error.message}", error)
+                close(error)
+                return@addSnapshotListener
+            }
+
+            if (snapshot == null) {
+                trySend(emptyMap())
+                return@addSnapshotListener
+            }
+
+            val votesMap = mutableMapOf<String, List<String>>()
+            snapshot.documents.forEach { doc ->
+                val time = doc.id
+                @Suppress("UNCHECKED_CAST")
+                val voters = doc.get("voters") as? List<String> ?: emptyList()
+                votesMap[time] = voters
+            }
+
+            Log.d(TAG, "📊 시간 투표 업데이트: $votesMap")
+            trySend(votesMap)
+        }
+
+        awaitClose { listenerRegistration.remove() }
+    }
+
+    /**
+     * 특정 날짜의 모든 시간 투표 조회
+     */
+    suspend fun getVotes(groupId: String, date: String): Map<String, List<String>> {
+        return try {
+            val snapshot = db.collection("groups")
+                .document(groupId)
+                .collection("timeVotes")
+                .document(date)
+                .collection("times")
+                .get()
+                .await()
+
+            val votesMap = mutableMapOf<String, List<String>>()
+            snapshot.documents.forEach { doc ->
+                val time = doc.id
+                @Suppress("UNCHECKED_CAST")
+                val voters = doc.get("voters") as? List<String> ?: emptyList()
+                votesMap[time] = voters
+            }
+
+            Log.d(TAG, "📥 시간 투표 조회 완료: $votesMap")
+            votesMap
+        } catch (e: Exception) {
+            Log.e(TAG, "❌ 시간 투표 조회 실패: ${e.message}", e)
+            emptyMap()
+        }
+    }
+
+    /**
+     * 모든 멤버의 투표를 기반으로 겹치는 시간 찾기
+     * @param groupId 그룹 ID
+     * @param date 날짜
+     * @param memberUids 모든 멤버 UID 리스트
+     * @return 겹치는 시간과 투표한 멤버 수 Map
+     */
+    suspend fun getOverlappingTimes(
+        groupId: String,
+        date: String,
+        memberUids: List<String>
+    ): Map<String, Int> {
+        val votes = getVotes(groupId, date)
+        val overlappingTimes = mutableMapOf<String, Int>()
+
+        votes.forEach { (time, voters) ->
+            val voteCount = voters.size
+            // 모든 멤버가 투표한 시간만 겹치는 시간으로 간주
+            if (voteCount == memberUids.size) {
+                overlappingTimes[time] = voteCount
+            }
+        }
+
+        Log.d(TAG, "🔍 겹치는 시간: $overlappingTimes")
+        return overlappingTimes
+    }
+
+    /**
+     * 최종 시간 투표 (겹치는 시간 중에서 선택)
+     * @param groupId 그룹 ID
+     * @param date 날짜
+     * @param time 선택한 시간
+     * @param uid 투표한 사용자 UID
+     */
+    suspend fun voteFinalTime(groupId: String, date: String, time: String, uid: String) {
+        try {
+            val finalVoteRef = db.collection("groups")
+                .document(groupId)
+                .collection("timeVotes")
+                .document(date)
+
+            // 각 사용자의 최종 투표 시간을 Map으로 저장 (uid -> time)
+            finalVoteRef.update(
+                "finalVotes.$uid", time,
+                "finalVotedUsers", FieldValue.arrayUnion(uid),
+                "updatedAt", com.google.firebase.firestore.FieldValue.serverTimestamp()
+            ).await()
+
+            Log.d(TAG, "✅ 최종 시간 투표 저장: groupId=$groupId, date=$date, time=$time, uid=$uid")
+        } catch (e: Exception) {
+            Log.e(TAG, "❌ 최종 시간 투표 저장 실패: ${e.message}", e)
+            throw e
+        }
+    }
+    
+    /**
+     * 최종 시간 투표에서 각 사용자가 선택한 시간 목록 조회
+     * @return List<String> - 각 사용자가 선택한 시간 리스트
+     */
+    suspend fun getFinalVotes(groupId: String, date: String): List<String> {
+        return try {
+            val doc = db.collection("groups")
+                .document(groupId)
+                .collection("timeVotes")
+                .document(date)
+                .get()
+                .await()
+
+            @Suppress("UNCHECKED_CAST")
+            val finalVotes = doc.get("finalVotes") as? Map<String, String> ?: emptyMap()
+            val times = finalVotes.values.toList()
+            Log.d(TAG, "📥 최종 시간 투표 목록: $times")
+            times
+        } catch (e: Exception) {
+            Log.e(TAG, "❌ 최종 시간 투표 목록 조회 실패: ${e.message}", e)
+            emptyList()
+        }
+    }
+
+    /**
+     * 최종 시간 투표 결과 조회
+     */
+    suspend fun getFinalTimeVote(groupId: String, date: String): String? {
+        return try {
+            val doc = db.collection("groups")
+                .document(groupId)
+                .collection("timeVotes")
+                .document(date)
+                .get()
+                .await()
+
+            val finalTime = doc.getString("finalTime")
+            Log.d(TAG, "📥 최종 시간 조회: $finalTime")
+            finalTime
+        } catch (e: Exception) {
+            Log.e(TAG, "❌ 최종 시간 조회 실패: ${e.message}", e)
+            null
+        }
+    }
+
+    /**
+     * 최종 시간 투표한 사용자 목록 조회
+     */
+    suspend fun getFinalVotedUsers(groupId: String, date: String): List<String> {
+        return try {
+            val doc = db.collection("groups")
+                .document(groupId)
+                .collection("timeVotes")
+                .document(date)
+                .get()
+                .await()
+
+            @Suppress("UNCHECKED_CAST")
+            val users = doc.get("finalVotedUsers") as? List<String> ?: emptyList()
+            Log.d(TAG, "📥 최종 시간 투표한 사용자: $users")
+            users
+        } catch (e: Exception) {
+            Log.e(TAG, "❌ 최종 시간 투표 사용자 조회 실패: ${e.message}", e)
+            emptyList()
+        }
+    }
+
+    /**
+     * 모든 멤버가 시간 투표를 완료했는지 확인
+     * @param groupId 그룹 ID
+     * @param date 날짜
+     * @param memberUids 모든 멤버 UID 리스트
+     * @return 모든 멤버가 투표했으면 true
+     */
+    suspend fun checkAllMembersVoted(groupId: String, date: String, memberUids: List<String>): Boolean {
+        if (memberUids.isEmpty()) return false
+        
+        return try {
+            val votes = getVotes(groupId, date)
+            val votedMembers = mutableSetOf<String>()
+            
+            votes.values.forEach { voters ->
+                votedMembers.addAll(voters)
+            }
+            
+            val allVoted = memberUids.all { it in votedMembers }
+            Log.d(TAG, "🔍 모든 멤버 투표 확인 - 전체: $memberUids, 투표한 멤버: $votedMembers, 모두 투표: $allVoted")
+            allVoted
+        } catch (e: Exception) {
+            Log.e(TAG, "❌ 모든 멤버 투표 확인 실패: ${e.message}", e)
+            false
+        }
+    }
+
+    /**
+     * 모든 멤버가 최종 시간 투표를 완료했는지 확인
+     * @param groupId 그룹 ID
+     * @param date 날짜
+     * @param memberUids 모든 멤버 UID 리스트
+     * @return 모든 멤버가 최종 투표했으면 true
+     */
+    suspend fun checkAllMembersFinalVoted(groupId: String, date: String, memberUids: List<String>): Boolean {
+        if (memberUids.isEmpty()) return false
+        
+        return try {
+            val finalVotedUsers = getFinalVotedUsers(groupId, date)
+            val allVoted = memberUids.all { it in finalVotedUsers }
+            Log.d(TAG, "🔍 모든 멤버 최종 투표 확인 - 전체: $memberUids, 최종 투표한 멤버: $finalVotedUsers, 모두 투표: $allVoted")
+            allVoted
+        } catch (e: Exception) {
+            Log.e(TAG, "❌ 모든 멤버 최종 투표 확인 실패: ${e.message}", e)
+            false
+        }
+    }
+
+    /**
+     * 최종 시간 투표를 실시간으로 관찰
+     * @return Flow<List<String>> - 최종 투표한 사용자 UID 리스트
+     */
+    fun observeFinalVotes(groupId: String, date: String): Flow<List<String>> = callbackFlow {
+        val finalVoteRef = db.collection("groups")
+            .document(groupId)
+            .collection("timeVotes")
+            .document(date)
+
+        val listenerRegistration = finalVoteRef.addSnapshotListener { snapshot, error ->
+            if (error != null) {
+                Log.e(TAG, "최종 시간 투표 리스너 오류: ${error.message}", error)
+                close(error)
+                return@addSnapshotListener
+            }
+
+            if (snapshot == null) {
+                trySend(emptyList())
+                return@addSnapshotListener
+            }
+
+            @Suppress("UNCHECKED_CAST")
+            val users = snapshot.get("finalVotedUsers") as? List<String> ?: emptyList()
+            Log.d(TAG, "📊 최종 시간 투표 업데이트: $users")
+            trySend(users)
+        }
+
+        awaitClose { listenerRegistration.remove() }
+    }
+}
+

--- a/app/src/main/java/com/moyeoyo/app/ui/groups/GroupDetailActivity.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/groups/GroupDetailActivity.kt
@@ -73,8 +73,16 @@ class GroupDetailActivity : AppCompatActivity() {
             showLeaveConfirmationDialog()
         }
 
-        // 중간값 계산 버튼 리스너
-        binding.btnCalculateMidpoint.setOnClickListener {
+        // 시간 투표 버튼 리스너
+        binding.btnTimeVote.setOnClickListener {
+            val intent = Intent(this, com.moyeoyo.app.ui.time.TimeVoteActivity::class.java).apply {
+                putExtra("groupId", groupId)
+            }
+            startActivity(intent)
+        }
+
+        // 장소 투표 버튼 리스너
+        binding.btnPlaceVote.setOnClickListener {
             // LocationInputActivity로 이동하여 위치 선택 화면 표시
             val intent = Intent(this, LocationInputActivity::class.java).apply {
                 putExtra("groupId", groupId)
@@ -127,7 +135,10 @@ class GroupDetailActivity : AppCompatActivity() {
                 binding.btnDeleteGroup.visibility = if (isHost) View.VISIBLE else View.GONE
                 binding.btnLeaveGroup.visibility = if (!isHost) View.VISIBLE else View.GONE
 
-                // 4. 팀원 목록 표시
+                // 4. 상태에 따른 버튼 활성화 제어
+                updateButtonsByStatus(group.status)
+
+                // 5. 팀원 목록 표시
                 displayMemberList(group.memberUids, group.hostUid, isHost)
 
             } else {
@@ -144,16 +155,23 @@ class GroupDetailActivity : AppCompatActivity() {
      */
     private fun displayConfirmedSchedule(group: Group) {
         val confirmedTime = group.confirmedTime
-        val confirmedPlace = group.confirmedPlace
 
-        if (confirmedTime != null && confirmedPlace != null) {
-            // 데이터가 있는 경우: 섹션을 표시하고 텍스트를 업데이트
-            val placeName = confirmedPlace["name"] as? String ?: confirmedPlace["address"] as? String ?: "장소 정보 없음"
+        if (confirmedTime != null) {
+            // 시간이 확정된 경우: 섹션을 표시하고 텍스트를 업데이트
             val formattedTime = formatTimestamp(confirmedTime)
 
             binding.confirmedScheduleSection.visibility = View.VISIBLE
-            binding.textConfirmedPlace.text = "장소: $placeName"
             binding.textConfirmedTime.text = "일시: $formattedTime"
+            
+            // 장소 정보가 있으면 표시
+            val confirmedPlace = group.confirmedPlace
+            if (confirmedPlace != null) {
+                val placeName = confirmedPlace["name"] as? String ?: confirmedPlace["address"] as? String ?: "장소 정보 없음"
+                binding.textConfirmedPlace.text = "장소: $placeName"
+                binding.textConfirmedPlace.visibility = View.VISIBLE
+            } else {
+                binding.textConfirmedPlace.visibility = View.GONE
+            }
         } else {
             // 데이터가 없는 경우: 섹션을 숨김
             binding.confirmedScheduleSection.visibility = View.GONE
@@ -170,6 +188,54 @@ class GroupDetailActivity : AppCompatActivity() {
             timeZone = TimeZone.getDefault()
         }
         return sdf.format(date)
+    }
+
+    /**
+     * 그룹 상태에 따라 버튼 활성화 제어
+     */
+    private fun updateButtonsByStatus(status: String?) {
+        android.util.Log.d("GroupDetailActivity", "📊 그룹 상태: $status")
+        
+        when (status) {
+            "GROUP_CREATED",
+            "TIME_VOTE_REQUIRED" -> {
+                // 시간 투표 단계
+                android.util.Log.d("GroupDetailActivity", "✅ 시간 투표 단계 - 시간 투표 활성화")
+                binding.btnTimeVote.isEnabled = true
+                binding.btnPlaceVote.isEnabled = false
+            }
+            "TIME_FINALIZING" -> {
+                // 시간 확정 단계 - 시간 투표만 활성화 (최종 시간 투표 진행 중)
+                android.util.Log.d("GroupDetailActivity", "⏳ 시간 확정 단계 - 시간 투표만 활성화")
+                binding.btnTimeVote.isEnabled = true
+                binding.btnPlaceVote.isEnabled = false
+            }
+            "LOCATION_INPUT_REQUIRED",
+            "LOCATION_DONE",
+            "PLACE_RANKING",
+            "FINAL_PLACE_VOTE",
+            "FINALIZED" -> {
+                // 장소 투표 단계 (시간 확정 완료)
+                android.util.Log.d("GroupDetailActivity", "✅ 장소 투표 단계 - 장소 투표 활성화")
+                binding.btnTimeVote.isEnabled = false
+                binding.btnPlaceVote.isEnabled = true
+            }
+            null,
+            "" -> {
+                // 상태가 없거나 빈 문자열인 경우 - 기본적으로 시간 투표 활성화
+                android.util.Log.w("GroupDetailActivity", "⚠️ 그룹 상태가 없음 - 기본값으로 시간 투표 활성화")
+                binding.btnTimeVote.isEnabled = true
+                binding.btnPlaceVote.isEnabled = false
+            }
+            else -> {
+                // 예상치 못한 상태 - 기본값으로 시간 투표 활성화
+                android.util.Log.w("GroupDetailActivity", "⚠️ 예상치 못한 그룹 상태: $status - 기본값으로 시간 투표 활성화")
+                binding.btnTimeVote.isEnabled = true
+                binding.btnPlaceVote.isEnabled = false
+            }
+        }
+        
+        android.util.Log.d("GroupDetailActivity", "버튼 상태 - 시간 투표: ${binding.btnTimeVote.isEnabled}, 장소 투표: ${binding.btnPlaceVote.isEnabled}")
     }
 
     /**

--- a/app/src/main/java/com/moyeoyo/app/ui/time/FinalTimeAdapter.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/time/FinalTimeAdapter.kt
@@ -1,0 +1,89 @@
+package com.moyeoyo.app.ui.time
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.moyeoyo.app.R
+import com.moyeoyo.app.databinding.ItemFinalTimeBinding
+
+class FinalTimeAdapter(
+    private val onTimeClick: (String) -> Unit
+) : ListAdapter<String, FinalTimeAdapter.ViewHolder>(TimeDiffCallback()) {
+
+    private var selectedTime: String? = null
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val binding = ItemFinalTimeBinding.inflate(
+            LayoutInflater.from(parent.context),
+            parent,
+            false
+        )
+        return ViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    fun updateSelection(time: String?) {
+        val previousSelected = selectedTime
+        selectedTime = time
+        
+        // 이전 선택 항목과 현재 선택 항목 업데이트
+        currentList.forEachIndexed { index, item ->
+            if (item == previousSelected || item == selectedTime) {
+                notifyItemChanged(index)
+            }
+        }
+    }
+
+    inner class ViewHolder(
+        private val binding: ItemFinalTimeBinding
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(time: String) {
+            binding.tvTime.text = time.replace(":00", "시")
+            
+            val isSelected = time == selectedTime
+            binding.root.isSelected = isSelected
+            
+            // 선택 상태에 따라 배경색 및 체크 아이콘 변경
+            if (isSelected) {
+                binding.root.setBackgroundColor(
+                    ContextCompat.getColor(binding.root.context, R.color.brand_blue)
+                )
+                binding.tvTime.setTextColor(
+                    ContextCompat.getColor(binding.root.context, R.color.white)
+                )
+                binding.ivCheck.visibility = View.VISIBLE
+            } else {
+                binding.root.setBackgroundColor(
+                    ContextCompat.getColor(binding.root.context, R.color.white)
+                )
+                binding.tvTime.setTextColor(
+                    ContextCompat.getColor(binding.root.context, R.color.black)
+                )
+                binding.ivCheck.visibility = View.GONE
+            }
+            
+            binding.root.setOnClickListener {
+                onTimeClick(time)
+            }
+        }
+    }
+
+    private class TimeDiffCallback : DiffUtil.ItemCallback<String>() {
+        override fun areItemsTheSame(oldItem: String, newItem: String): Boolean {
+            return oldItem == newItem
+        }
+
+        override fun areContentsTheSame(oldItem: String, newItem: String): Boolean {
+            return oldItem == newItem
+        }
+    }
+}
+

--- a/app/src/main/java/com/moyeoyo/app/ui/time/FinalTimeVoteActivity.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/time/FinalTimeVoteActivity.kt
@@ -1,0 +1,250 @@
+package com.moyeoyo.app.ui.time
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.firebase.auth.FirebaseAuth
+import com.moyeoyo.app.R
+import com.moyeoyo.app.data.repository.GroupRepository
+import com.moyeoyo.app.data.repository.TimeVoteRepository
+import com.moyeoyo.app.databinding.ActivityFinalTimeVoteBinding
+import com.moyeoyo.app.ui.groups.GroupDetailActivity
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class FinalTimeVoteActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityFinalTimeVoteBinding
+    
+    @Inject
+    lateinit var timeVoteRepository: TimeVoteRepository
+    
+    @Inject
+    lateinit var groupRepository: GroupRepository
+    
+    private val auth = FirebaseAuth.getInstance()
+    
+    private lateinit var groupId: String
+    private lateinit var date: String
+    private var selectedTime: String? = null
+    private val overlappingTimes = mutableListOf<Pair<String, Int>>() // 시간과 투표 수
+    
+    private lateinit var adapter: FinalTimeAdapter
+    private var winningTimeDialog: AlertDialog? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityFinalTimeVoteBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        groupId = intent.getStringExtra("groupId") ?: run {
+            Toast.makeText(this, "그룹 ID가 없습니다.", Toast.LENGTH_SHORT).show()
+            finish()
+            return
+        }
+        
+        date = intent.getStringExtra("date") ?: run {
+            Toast.makeText(this, "날짜가 없습니다.", Toast.LENGTH_SHORT).show()
+            finish()
+            return
+        }
+
+        setupViews()
+        setupRecyclerView()
+        loadOverlappingTimes()
+        observeFinalVotes()
+    }
+
+    private fun setupViews() {
+        binding.toolbar.setNavigationOnClickListener {
+            finish()
+        }
+
+        binding.btnSubmitVote.setOnClickListener {
+            selectedTime?.let { time ->
+                submitFinalVote(time)
+            } ?: run {
+                Toast.makeText(this, "시간을 선택해주세요.", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    private fun setupRecyclerView() {
+        adapter = FinalTimeAdapter { time ->
+            // 선택된 시간 업데이트
+            selectedTime = if (selectedTime == time) {
+                null // 같은 시간 클릭 시 선택 해제
+            } else {
+                time
+            }
+            
+            // 어댑터 업데이트
+            adapter.updateSelection(selectedTime)
+            
+            // 투표 버튼 표시
+            binding.btnSubmitVote.visibility = if (selectedTime != null) View.VISIBLE else View.GONE
+        }
+        
+        binding.rvFinalTimes.layoutManager = LinearLayoutManager(this)
+        binding.rvFinalTimes.adapter = adapter
+    }
+
+    private fun loadOverlappingTimes() {
+        lifecycleScope.launch {
+            try {
+                // 그룹 정보 가져오기
+                val group = groupRepository.getGroupDetail(groupId)
+                val memberUids = group?.memberUids ?: emptyList()
+                
+                if (memberUids.isEmpty()) {
+                    Toast.makeText(this@FinalTimeVoteActivity, "멤버 정보를 불러올 수 없습니다.", Toast.LENGTH_SHORT).show()
+                    finish()
+                    return@launch
+                }
+                
+                // 겹치는 시간 가져오기
+                val overlapping = timeVoteRepository.getOverlappingTimes(groupId, date, memberUids)
+                
+                if (overlapping.isEmpty()) {
+                    binding.tvEmptyMessage.visibility = View.VISIBLE
+                    binding.rvFinalTimes.visibility = View.GONE
+                    binding.btnSubmitVote.visibility = View.GONE
+                    Toast.makeText(this@FinalTimeVoteActivity, "모든 멤버가 겹치는 시간이 없습니다.", Toast.LENGTH_LONG).show()
+                    return@launch
+                }
+                
+                // 시간과 투표 수를 리스트로 변환 (투표 수 내림차순 정렬)
+                overlappingTimes.clear()
+                overlappingTimes.addAll(overlapping.toList().sortedByDescending { it.second })
+                
+                // 어댑터에 데이터 전달
+                adapter.submitList(overlappingTimes.map { it.first })
+                
+                binding.tvEmptyMessage.visibility = View.GONE
+                binding.rvFinalTimes.visibility = View.VISIBLE
+                
+            } catch (e: Exception) {
+                Toast.makeText(this@FinalTimeVoteActivity, "데이터를 불러오는 중 오류 발생: ${e.message}", Toast.LENGTH_SHORT).show()
+                finish()
+            }
+        }
+    }
+
+    /**
+     * 최종 시간 투표를 실시간으로 관찰하여 모든 멤버 투표 완료 시 자동으로 시간 확정
+     */
+    private fun observeFinalVotes() {
+        lifecycleScope.launch {
+            try {
+                val group = groupRepository.getGroupDetail(groupId)
+                val memberUids = group?.memberUids ?: emptyList()
+                
+                if (memberUids.isEmpty()) {
+                    return@launch
+                }
+                
+                timeVoteRepository.observeFinalVotes(groupId, date).collectLatest { finalVotedUsers ->
+                    val allVoted = memberUids.all { it in finalVotedUsers }
+                    
+                    if (allVoted && finalVotedUsers.isNotEmpty()) {
+                        android.util.Log.d("FinalTimeVoteActivity", "✅ 모든 멤버 최종 투표 완료! 시간 확정합니다.")
+                        
+                        // 최종 시간 가져오기: 최종 투표에서 가장 많이 선택된 시간
+                        val finalVotes = timeVoteRepository.getFinalVotes(groupId, date)
+                        val finalTime = if (finalVotes.isNotEmpty()) {
+                            // 최종 투표에서 가장 많이 선택된 시간 찾기
+                            val voteCounts = finalVotes.groupingBy { it }.eachCount()
+                            voteCounts.maxByOrNull { it.value }?.key ?: overlappingTimes.firstOrNull()?.first
+                        } else {
+                            // 최종 투표가 없으면 겹치는 시간 중 첫 번째
+                            overlappingTimes.firstOrNull()?.first
+                        }
+                        
+                        if (finalTime == null) {
+                            android.util.Log.e("FinalTimeVoteActivity", "최종 시간을 결정할 수 없습니다.")
+                            return@collectLatest
+                        }
+                        
+                        // 최종 시간 확정
+                        val success = groupRepository.setFinalTime(groupId, date, finalTime)
+                        
+                        if (success) {
+                            // 그룹 상태를 LOCATION_INPUT_REQUIRED로 변경
+                            groupRepository.updateGroupStatus(groupId, "LOCATION_INPUT_REQUIRED")
+                            
+                            // 승리한 시간 다이얼로그 표시
+                            showWinningTimeDialog(finalTime)
+                        } else {
+                            Toast.makeText(this@FinalTimeVoteActivity, "시간 확정에 실패했습니다.", Toast.LENGTH_SHORT).show()
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                android.util.Log.e("FinalTimeVoteActivity", "최종 투표 관찰 중 오류: ${e.message}", e)
+            }
+        }
+    }
+
+    private fun submitFinalVote(time: String) {
+        val uid = auth.currentUser?.uid ?: return
+        
+        lifecycleScope.launch {
+            try {
+                // 최종 시간 투표 저장
+                timeVoteRepository.voteFinalTime(groupId, date, time, uid)
+                
+                Toast.makeText(this@FinalTimeVoteActivity, "투표가 저장되었습니다 ✅", Toast.LENGTH_SHORT).show()
+                
+                // ⚠️ 실시간 관찰(observeFinalVotes)에서 모든 멤버 투표 완료 시 자동으로 시간 확정
+                // 여기서는 투표만 저장하고, observeFinalVotes에서 처리
+            } catch (e: Exception) {
+                Toast.makeText(this@FinalTimeVoteActivity, "투표 저장 중 오류 발생: ${e.message}", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    private fun showWinningTimeDialog(time: String) {
+        winningTimeDialog?.dismiss()
+        
+        lifecycleScope.launch {
+            val group = groupRepository.getGroupDetail(groupId)
+            val groupName = group?.groupName ?: ""
+            
+            // 날짜 포맷팅
+            val dateFormat = java.text.SimpleDateFormat("yyyy년 MM월 dd일 (E)", java.util.Locale.KOREA)
+            val dateObj = java.text.SimpleDateFormat("yyyy-MM-dd", java.util.Locale.KOREA).parse(date)
+            val formattedDate = dateObj?.let { dateFormat.format(it) } ?: date
+            
+            winningTimeDialog = AlertDialog.Builder(this@FinalTimeVoteActivity)
+                .setTitle("최종 약속 시간 확정")
+                .setMessage("최종 약속 일시는 \"${formattedDate} ${time}\"로 선정되었습니다.\n이제 장소 투표를 진행할 수 있습니다.")
+                .setPositiveButton("확인") { _, _ ->
+                    // GroupDetailActivity로 이동
+                    val intent = Intent(this@FinalTimeVoteActivity, GroupDetailActivity::class.java).apply {
+                        putExtra("GROUP_ID", groupId)
+                        putExtra("GROUP_NAME", groupName)
+                    }
+                    startActivity(intent)
+                    finish()
+                }
+                .setCancelable(false)
+                .create()
+            
+            winningTimeDialog?.show()
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        winningTimeDialog?.dismiss()
+    }
+}
+

--- a/app/src/main/java/com/moyeoyo/app/ui/time/TimeVoteActivity.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/time/TimeVoteActivity.kt
@@ -1,0 +1,798 @@
+package com.moyeoyo.app.ui.time
+
+import android.graphics.Rect
+import android.os.Bundle
+import android.view.MotionEvent
+import android.view.View
+import android.widget.LinearLayout
+import android.widget.TextView
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.lifecycleScope
+import com.google.android.material.appbar.MaterialToolbar
+import com.google.android.material.button.MaterialButton
+import com.google.firebase.auth.FirebaseAuth
+import com.moyeoyo.app.R
+import com.moyeoyo.app.data.repository.GroupRepository
+import com.moyeoyo.app.data.repository.TimeVoteRepository
+import com.moyeoyo.app.databinding.ActivityTimeVoteBinding
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.*
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class TimeVoteActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityTimeVoteBinding
+    
+    @Inject
+    lateinit var timeVoteRepository: TimeVoteRepository
+    
+    @Inject
+    lateinit var groupRepository: GroupRepository
+    
+    private val auth = FirebaseAuth.getInstance()
+
+    private lateinit var groupId: String
+    private val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.KOREA)
+    private var selectedDate: Date = Date()
+    private val calendar = Calendar.getInstance()
+
+    // 날짜별로 선택된 시간 관리 (날짜 문자열 -> 시간 Set)
+    private val selectedTimesByDate = mutableMapOf<String, MutableSet<String>>()
+    private val selectedTimes: MutableSet<String>
+        get() = selectedTimesByDate.getOrPut(dateFormat.format(selectedDate)) { mutableSetOf() }
+    
+    private var selectedDayButton: View? = null
+
+    // 드래그용 시간 버튼 리스트
+    private val timeButtons = mutableListOf<MaterialButton>()
+    
+    // 모든 멤버 투표 완료 확인 플래그 (중복 화면 전환 방지)
+    private var hasNavigatedToFinalVote = false
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityTimeVoteBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        groupId = intent.getStringExtra("groupId") ?: run {
+            Toast.makeText(this, "그룹 ID가 없습니다.", Toast.LENGTH_SHORT).show()
+            finish()
+            return
+        }
+
+        setupToolbar()
+        setupWeekHeader()
+        setupTimeGrid()
+        setupButton()
+        observeFirestoreVotes()
+        
+        // 초기화 시 모든 날짜에 대해 모든 멤버 투표 완료 확인
+        lifecycleScope.launch {
+            checkAllDatesVoted()
+        }
+
+        // 스크롤뷰 설정 & 드래그 리스너
+        binding.scrollViewTimeSlots.isNestedScrollingEnabled = false
+        binding.scrollViewTimeSlots.setOnTouchListener { _, event ->
+            handleDragSelect(event)
+            true
+        }
+    }
+
+    // ----------------------- 드래그 선택 -----------------------
+
+    private fun handleDragSelect(event: MotionEvent) {
+        binding.scrollViewTimeSlots.requestDisallowInterceptTouchEvent(true)
+
+        val x = event.rawX.toInt()
+        val y = event.rawY.toInt()
+
+        when (event.action) {
+            MotionEvent.ACTION_DOWN,
+            MotionEvent.ACTION_MOVE -> {
+                timeButtons.forEach { button ->
+                    val rect = Rect()
+                    button.getGlobalVisibleRect(rect)
+
+                    if (rect.contains(x, y)) {
+                        selectTimeSlot(button)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun selectTimeSlot(button: MaterialButton) {
+        // ⚠️ tag를 Boolean으로 안전하게 캐스팅
+        val isAlreadySelected = button.tag as? Boolean == true
+        if (isAlreadySelected) return  // 이미 선택된 버튼이면 무시
+
+        val time = button.text.toString()
+        button.tag = true
+        selectedTimes.add(time)
+
+        button.backgroundTintList =
+            ContextCompat.getColorStateList(this, R.color.brand_blue)
+        button.setTextColor(ContextCompat.getColor(this, R.color.white))
+
+        updateButtonState()
+    }
+
+    // ----------------------- 상단 UI -----------------------
+
+    private fun setupToolbar() {
+        binding.toolbar.setNavigationOnClickListener {
+            finish()
+        }
+    }
+
+    private fun setupWeekHeader() {
+        updateWeekTitle()
+
+        binding.btnPrevWeek.setOnClickListener {
+            calendar.add(Calendar.WEEK_OF_YEAR, -1)
+            setupWeekDays()
+            updateWeekTitle()
+            // 주 변경 시 모든 날짜 관찰 다시 시작
+            observeFirestoreVotes()
+        }
+
+        binding.btnNextWeek.setOnClickListener {
+            calendar.add(Calendar.WEEK_OF_YEAR, 1)
+            setupWeekDays()
+            updateWeekTitle()
+            // 주 변경 시 모든 날짜 관찰 다시 시작
+            observeFirestoreVotes()
+        }
+
+        setupWeekDays()
+    }
+
+    private fun updateWeekTitle() {
+        val month = calendar.get(Calendar.MONTH) + 1
+        val weekOfMonth = calendar.get(Calendar.WEEK_OF_MONTH)
+        binding.tvWeekTitle.text = "${month}월 ${weekOfMonth}째주"
+    }
+
+    private fun setupWeekDays() {
+        val layout = binding.layoutWeekDays
+        layout.removeAllViews()
+
+        val tempCal = calendar.clone() as Calendar
+        tempCal.set(Calendar.DAY_OF_WEEK, Calendar.MONDAY)
+
+        val dayFormat = SimpleDateFormat("MM월 dd일", Locale.KOREA)
+        val weekDays = listOf("월", "화", "수", "목", "금", "토", "일")
+
+        for (i in 0 until 7) {
+            val date = tempCal.time
+            val dayLabel = weekDays[i]
+
+            val button = LinearLayout(this).apply {
+                orientation = LinearLayout.VERTICAL
+                layoutParams =
+                    LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
+                setPadding(4, 8, 4, 8)
+                setOnClickListener {
+                    selectedDate = date
+                    highlightSelectedDay(this)
+                    hasNavigatedToFinalVote = false // 날짜 변경 시 플래그 리셋
+                    
+                    // 날짜 변경 시 시간 그리드만 업데이트 (관찰은 이미 모든 날짜를 관찰 중)
+                    setupTimeGrid()
+                    updateButtonState() // 날짜 변경 시 버튼 상태 업데이트
+                }
+            }
+
+            val dayText = TextView(this).apply {
+                text = dayLabel
+                textAlignment = TextView.TEXT_ALIGNMENT_CENTER
+                setTextColor(ContextCompat.getColor(this@TimeVoteActivity, R.color.black))
+                textSize = 13f
+            }
+
+            val dateText = TextView(this).apply {
+                text = dayFormat.format(date)
+                textAlignment = TextView.TEXT_ALIGNMENT_CENTER
+                setTextColor(ContextCompat.getColor(this@TimeVoteActivity, R.color.text_secondary))
+                textSize = 12f
+            }
+
+            button.addView(dayText)
+            button.addView(dateText)
+
+            layout.addView(button)
+
+            if (isSameDay(date, Date())) {
+                selectedDate = date
+                highlightSelectedDay(button)
+            }
+
+            tempCal.add(Calendar.DAY_OF_MONTH, 1)
+        }
+    }
+
+    private fun highlightSelectedDay(selectedButton: View) {
+        selectedDayButton?.background = null
+        selectedButton.setBackgroundResource(R.drawable.bg_light_gray_outline)
+        selectedDayButton = selectedButton
+    }
+
+    private fun isSameDay(d1: Date, d2: Date): Boolean {
+        val cal1 = Calendar.getInstance().apply { time = d1 }
+        val cal2 = Calendar.getInstance().apply { time = d2 }
+        return cal1.get(Calendar.YEAR) == cal2.get(Calendar.YEAR) &&
+                cal1.get(Calendar.DAY_OF_YEAR) == cal2.get(Calendar.DAY_OF_YEAR)
+    }
+
+    // ----------------------- 시간 버튼 -----------------------
+
+    private fun setupTimeGrid() {
+        val grid = binding.gridTimeSlots
+        grid.removeAllViews()
+        timeButtons.clear()
+        
+        // 현재 선택된 날짜의 선택된 시간 가져오기
+        val dateStr = dateFormat.format(selectedDate)
+        val currentDateSelectedTimes = selectedTimesByDate.getOrPut(dateStr) { mutableSetOf() }
+
+        val times = (0..23).map { String.format(Locale.KOREA, "%02d시", it) }
+
+        times.forEach { time ->
+            val isSelected = currentDateSelectedTimes.contains(time)
+            
+            val button = MaterialButton(this).apply {
+                text = time
+                tag = isSelected
+
+                layoutParams = android.widget.GridLayout.LayoutParams().apply {
+                    width = 0
+                    columnSpec = android.widget.GridLayout.spec(
+                        android.widget.GridLayout.UNDEFINED,
+                        1f
+                    )
+                    setMargins(12, 12, 12, 12)
+                }
+                setPadding(0, 24, 0, 24)
+                setBackgroundResource(R.drawable.bg_time_slot_card)
+                
+                // 선택된 시간은 파란색으로 표시
+                if (isSelected) {
+                    backgroundTintList =
+                        ContextCompat.getColorStateList(this@TimeVoteActivity, R.color.brand_blue)
+                    setTextColor(ContextCompat.getColor(this@TimeVoteActivity, R.color.white))
+                } else {
+                    backgroundTintList =
+                        ContextCompat.getColorStateList(this@TimeVoteActivity, R.color.white)
+                    setTextColor(ContextCompat.getColor(this@TimeVoteActivity, R.color.black))
+                }
+
+                setOnClickListener {
+                    val wasSelected = tag as Boolean
+                    tag = !wasSelected
+                    if (!wasSelected) {
+                        selectedTimes.add(time)
+                        backgroundTintList =
+                            ContextCompat.getColorStateList(this@TimeVoteActivity, R.color.brand_blue)
+                        setTextColor(
+                            ContextCompat.getColor(
+                                this@TimeVoteActivity,
+                                R.color.white
+                            )
+                        )
+                    } else {
+                        selectedTimes.remove(time)
+                        backgroundTintList =
+                            ContextCompat.getColorStateList(this@TimeVoteActivity, R.color.white)
+                        setTextColor(
+                            ContextCompat.getColor(
+                                this@TimeVoteActivity,
+                                R.color.black
+                            )
+                        )
+                    }
+                    updateButtonState()
+                }
+            }
+
+            grid.addView(button)
+            timeButtons.add(button)
+        }
+        
+        // 버튼 상태 업데이트
+        updateButtonState()
+    }
+
+    // ----------------------- Firestore 연동 -----------------------
+    
+    private var currentVoteObserver: kotlinx.coroutines.Job? = null
+
+    private fun observeFirestoreVotes() {
+        val uid = auth.currentUser?.uid ?: return
+
+        // 이전 관찰자 취소
+        currentVoteObserver?.cancel()
+        
+        // 현재 주의 모든 날짜를 관찰
+        currentVoteObserver = lifecycleScope.launch {
+            val tempCal = calendar.clone() as Calendar
+            tempCal.set(Calendar.DAY_OF_WEEK, Calendar.MONDAY)
+            
+            val datesToObserve = mutableListOf<String>()
+            for (i in 0 until 7) {
+                val dateStr = dateFormat.format(tempCal.time)
+                datesToObserve.add(dateStr)
+                tempCal.add(Calendar.DAY_OF_MONTH, 1)
+            }
+            
+            // 모든 날짜의 Flow를 합쳐서 관찰
+            val flows = datesToObserve.map { dateStr ->
+                timeVoteRepository.observeVotes(groupId, dateStr)
+            }
+            
+            // 모든 Flow를 병합하여 관찰
+            combine(flows) { arrays ->
+                arrays.map { it as Map<String, List<String>> }
+            }
+            .debounce(500) // 500ms debounce로 중복 호출 방지
+            .collectLatest { allDatesData ->
+                // 현재 선택된 날짜의 데이터로 그리드 업데이트
+                val currentDateStr = dateFormat.format(selectedDate)
+                val currentDateIndex = datesToObserve.indexOf(currentDateStr)
+                if (currentDateIndex >= 0 && currentDateIndex < allDatesData.size) {
+                    updateGridFromFirestore(allDatesData[currentDateIndex], uid)
+                }
+                
+                // ⚠️ 실시간으로 모든 날짜에 대해 모든 멤버 투표 완료 확인
+                if (!hasNavigatedToFinalVote) {
+                    try {
+                        checkAllDatesVoted()
+                    } catch (e: Exception) {
+                        android.util.Log.e("TimeVoteActivity", "투표 확인 중 오류: ${e.message}", e)
+                    }
+                }
+            }
+        }
+    }
+    
+
+    private fun updateGridFromFirestore(data: Map<String, List<String>>, uid: String) {
+        val grid = binding.gridTimeSlots
+        val dateStr = dateFormat.format(selectedDate)
+        val currentDateSelectedTimes = selectedTimesByDate.getOrPut(dateStr) { mutableSetOf() }
+
+        for (i in 0 until grid.childCount) {
+            val button = grid.getChildAt(i) as MaterialButton
+            val timeKey = button.text.toString().replace("시", ":00")
+            val voters = data[timeKey] ?: emptyList()
+            val isMyVote = voters.contains(uid)
+
+            if (isMyVote) {
+                button.tag = true
+                button.backgroundTintList =
+                    ContextCompat.getColorStateList(this, R.color.brand_blue)
+                button.setTextColor(ContextCompat.getColor(this, R.color.white))
+                // ⚠️ selectedTimes에도 추가해야 함 (중복 방지)
+                val timeText = button.text.toString()
+                if (!currentDateSelectedTimes.contains(timeText)) {
+                    currentDateSelectedTimes.add(timeText)
+                }
+            } else {
+                button.tag = false
+                button.backgroundTintList =
+                    ContextCompat.getColorStateList(this, R.color.white)
+                button.setTextColor(ContextCompat.getColor(this, R.color.black))
+                // ⚠️ selectedTimes에서도 제거해야 함
+                val timeText = button.text.toString()
+                currentDateSelectedTimes.remove(timeText)
+            }
+        }
+
+        updateButtonState()
+    }
+
+    // ----------------------- 하단 버튼 -----------------------
+
+    private fun updateButtonState() {
+        // 모든 날짜의 선택된 시간 개수 계산
+        val totalCount = selectedTimesByDate.values.sumOf { it.size }
+        val dateCount = selectedTimesByDate.count { it.value.isNotEmpty() }
+        
+        if (dateCount > 0) {
+            binding.btnCompleteVote.text = "저장 (${dateCount}개 날짜, ${totalCount}개 시간)"
+        } else {
+            binding.btnCompleteVote.text = "저장"
+        }
+
+        val enabled = totalCount > 0
+        binding.btnCompleteVote.isEnabled = enabled
+        binding.btnCompleteVote.backgroundTintList =
+            ContextCompat.getColorStateList(
+                this,
+                if (enabled) R.color.black else R.color.light_gray
+            )
+    }
+
+    private fun setupButton() {
+        binding.btnCompleteVote.setOnClickListener {
+            // 모든 날짜의 선택된 시간 확인
+            val datesWithTimes = selectedTimesByDate.filter { it.value.isNotEmpty() }
+            
+            if (datesWithTimes.isEmpty()) {
+                Toast.makeText(this, "선택된 시간이 없습니다", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            }
+
+            val dateDisplayFormat = SimpleDateFormat("yyyy년 MM월 dd일 (E)", Locale.KOREA)
+            
+            // 여러 날짜 정보를 메시지로 구성 - 실제 시간 목록 표시
+            val message = buildString {
+                append("다음 날짜에 선택한 시간을 최종적으로 저장하시겠습니까?\n\n")
+                datesWithTimes.forEach { (dateStr, times) ->
+                    val date = dateFormat.parse(dateStr) ?: return@buildString
+                    val dateDisplay = dateDisplayFormat.format(date)
+                    append("• $dateDisplay:\n")
+                    // 시간을 정렬하여 표시
+                    val sortedTimes = times.sorted()
+                    sortedTimes.forEach { time ->
+                        append("  - $time\n")
+                    }
+                }
+            }
+            
+            // 확인 팝업 표시
+            androidx.appcompat.app.AlertDialog.Builder(this)
+                .setTitle("시간 저장 확인")
+                .setMessage(message)
+                .setPositiveButton("저장") { _, _ ->
+                    saveAllSelectedTimes(datesWithTimes)
+                }
+                .setNegativeButton("취소", null)
+                .show()
+        }
+    }
+    
+    /**
+     * 모든 날짜의 선택된 시간을 한 번에 저장
+     */
+    private fun saveAllSelectedTimes(datesWithTimes: Map<String, MutableSet<String>>) {
+        val uid = auth.currentUser?.uid ?: return
+
+        lifecycleScope.launch {
+            try {
+                // 중복 클릭 방지
+                binding.btnCompleteVote.isEnabled = false
+                
+                android.util.Log.d("TimeVoteActivity", "📝 저장 시작: ${datesWithTimes.size}개 날짜의 시간 투표 저장")
+                
+                // ⚠️ 모든 날짜의 모든 시간 저장 작업을 병렬로 실행하고 완료될 때까지 대기
+                coroutineScope {
+                    val allTasks = mutableListOf<kotlinx.coroutines.Deferred<Unit>>()
+                    
+                    datesWithTimes.forEach { (dateStr, times) ->
+                        times.forEach { time ->
+                            val task = async(Dispatchers.IO) {
+                                val formattedTime = time.replace("시", ":00")
+                                timeVoteRepository.voteTime(groupId, dateStr, formattedTime, uid)
+                            }
+                            allTasks.add(task)
+                        }
+                    }
+                    
+                    allTasks.awaitAll() // 모든 저장 작업이 완료될 때까지 여기서 대기
+                }
+                
+                val totalCount = datesWithTimes.values.sumOf { it.size }
+                android.util.Log.d("TimeVoteActivity", "✅ 모든 시간 저장 작업 완료 (${datesWithTimes.size}개 날짜, ${totalCount}개 시간). 이제 멤버 투표 완료 여부를 확인합니다.")
+                
+                // 그룹 상태 확인 및 업데이트
+                val group = groupRepository.getGroupDetail(groupId)
+                if (group != null && group.status == "GROUP_CREATED") {
+                    // 첫 투표 시 상태를 TIME_VOTE_REQUIRED로 변경
+                    groupRepository.updateGroupStatus(groupId, "TIME_VOTE_REQUIRED")
+                }
+
+                Toast.makeText(this@TimeVoteActivity, "${datesWithTimes.size}개 날짜의 시간이 저장되었습니다 ✅", Toast.LENGTH_SHORT).show()
+                
+                // Firestore 동기화를 위해 잠시 대기 (1초)
+                delay(1000)
+                
+                // 저장 직후 모든 멤버 투표 완료 여부 확인
+                val allVoted = checkAllDatesVotedSync()
+                
+                if (allVoted != null) {
+                    dismissWaitingDialog()
+                    
+                    if (allVoted.second.isEmpty()) {
+                        // 모든 멤버가 투표했지만 겹치는 시간이 없음
+                        android.util.Log.d("TimeVoteActivity", "⚠️ 모든 멤버 투표 완료했지만 겹치는 시간이 없음")
+                        showNoOverlappingTimeDialog()
+                    } else {
+                        // 모든 멤버가 투표 완료하고 겹치는 시간이 있음 -> 바로 확인 팝업 표시
+                        android.util.Log.d("TimeVoteActivity", "✅ 저장 직후 모든 멤버 투표 완료 확인!")
+                        showFinalVoteConfirmationDialog(allVoted.first, allVoted.second)
+                    }
+                } else {
+                    // 아직 다른 멤버가 남았다면 대기 다이얼로그 표시
+                    android.util.Log.d("TimeVoteActivity", "⏳ 다른 멤버들의 투표를 기다리는 중...")
+                    showWaitingForMembersDialog()
+                }
+                
+            } catch (e: CancellationException) {
+                // 사용자가 화면을 나가는 등 정상적인 취소는 오류로 보지 않음
+                android.util.Log.w("TimeVoteActivity", "저장 작업이 취소되었습니다: ${e.message}")
+                // CancellationException은 다시 throw하지 않음 (정상적인 취소)
+            } catch (e: Exception) {
+                android.util.Log.e("TimeVoteActivity", "투표 저장 중 오류 발생: ${e.message}", e)
+                Toast.makeText(this@TimeVoteActivity, "투표 저장 중 오류 발생: ${e.message}", Toast.LENGTH_SHORT).show()
+            } finally {
+                // 작업이 끝나면 버튼 다시 활성화 (화면이 아직 살아있다면)
+                if (!isFinishing && !isDestroyed) {
+                    binding.btnCompleteVote.isEnabled = true
+                }
+            }
+        }
+    }
+    
+    private var waitingDialog: androidx.appcompat.app.AlertDialog? = null
+    
+    /**
+     * 다른 멤버 투표 대기 중 메시지 표시
+     */
+    private fun showWaitingForMembersDialog() {
+        // 이미 표시 중이면 무시
+        if (waitingDialog?.isShowing == true) {
+            return
+        }
+        
+        waitingDialog = androidx.appcompat.app.AlertDialog.Builder(this)
+            .setTitle("시간 투표 대기 중")
+            .setMessage("다른 멤버의 시간 투표를 기다리는 중입니다...")
+            .setCancelable(false)
+            .create()
+        
+        waitingDialog?.show()
+    }
+    
+    /**
+     * 대기 중 메시지 닫기
+     */
+    private fun dismissWaitingDialog() {
+        waitingDialog?.dismiss()
+        waitingDialog = null
+    }
+    
+    /**
+     * 모든 멤버가 투표했는지 동기적으로 확인 (저장 직후 확인용)
+     * @return Triple<날짜, 겹치는 시간 목록, 모든 멤버 투표 완료 여부> 또는 null
+     *         - null: 아직 모든 멤버가 투표하지 않음
+     *         - Triple(date, emptyList(), true): 모든 멤버가 투표했지만 겹치는 시간이 없음
+     *         - Triple(date, times, true): 모든 멤버가 투표했고 겹치는 시간이 있음
+     */
+    private suspend fun checkAllDatesVotedSync(): Triple<String, List<String>, Boolean>? {
+        try {
+            val group = try {
+                groupRepository.getGroupDetail(groupId)
+            } catch (e: CancellationException) {
+                android.util.Log.w("TimeVoteActivity", "그룹 조회 취소됨: ${e.message}")
+                return null
+            } catch (e: Exception) {
+                android.util.Log.e("TimeVoteActivity", "그룹 조회 실패: ${e.message}", e)
+                return null
+            }
+            
+            val memberUids = group?.memberUids ?: emptyList()
+            
+            if (memberUids.isEmpty()) {
+                return null
+            }
+            
+            // 현재 주의 모든 날짜 확인 (월~일, 7일)
+            val tempCal = calendar.clone() as Calendar
+            tempCal.set(Calendar.DAY_OF_WEEK, Calendar.MONDAY)
+            
+            val datesToCheck = mutableListOf<String>()
+            for (i in 0 until 7) {
+                val dateStr = dateFormat.format(tempCal.time)
+                datesToCheck.add(dateStr)
+                tempCal.add(Calendar.DAY_OF_MONTH, 1)
+            }
+            
+            // 모든 멤버가 투표한 날짜 찾기
+            var dateWithAllVoted: String? = null
+            for (dateStr in datesToCheck) {
+                val allVoted = timeVoteRepository.checkAllMembersVoted(groupId, dateStr, memberUids)
+                if (allVoted) {
+                    dateWithAllVoted = dateStr
+                    break
+                }
+            }
+            
+            // 모든 멤버가 투표한 날짜가 없으면 null 반환
+            if (dateWithAllVoted == null) {
+                return null
+            }
+            
+            // 모든 멤버가 투표한 날짜에서 겹치는 시간 확인
+            val overlapping = timeVoteRepository.getOverlappingTimes(groupId, dateWithAllVoted, memberUids)
+            if (overlapping.isNotEmpty()) {
+                // 시간 형식 변환: "14:00" -> "14시"
+                val overlappingTimes = overlapping.keys.sorted().map { timeStr ->
+                    val hour = timeStr.split(":")[0].toIntOrNull() ?: 0
+                    "${hour}시"
+                }
+                return Triple(dateWithAllVoted, overlappingTimes, true)
+            } else {
+                // 모든 멤버가 투표했지만 겹치는 시간이 없음
+                return Triple(dateWithAllVoted, emptyList(), true)
+            }
+        } catch (e: Exception) {
+            android.util.Log.e("TimeVoteActivity", "모든 날짜 투표 확인 중 오류: ${e.message}", e)
+            return null
+        }
+    }
+    
+    /**
+     * 겹치는 시간이 없을 때 팝업 표시
+     */
+    private fun showNoOverlappingTimeDialog() {
+        androidx.appcompat.app.AlertDialog.Builder(this)
+            .setTitle("겹치는 시간 없음")
+            .setMessage("겹치는 시간이 없습니다.\n상의 후 투표를 다시 진행해주세요.")
+            .setPositiveButton("확인") { _, _ ->
+                // 확인 버튼 클릭 시 대기 다이얼로그 닫기
+                dismissWaitingDialog()
+                // 사용자가 다시 시간을 선택할 수 있도록 화면 유지
+                android.util.Log.d("TimeVoteActivity", "겹치는 시간 없음 - 사용자가 다시 시간 선택 가능")
+            }
+            .setCancelable(true)
+            .show()
+    }
+    
+    /**
+     * 최종 투표 확인 팝업 표시
+     */
+    private fun showFinalVoteConfirmationDialog(dateWithAllVoted: String, overlappingTimes: List<String>) {
+        if (hasNavigatedToFinalVote) return
+        
+        val dateDisplayFormat = SimpleDateFormat("yyyy년 MM월 dd일 (E)", Locale.KOREA)
+        val date = dateFormat.parse(dateWithAllVoted)
+        val dateDisplay = date?.let { dateDisplayFormat.format(it) } ?: dateWithAllVoted
+        
+        val message = buildString {
+            append("모든 멤버의 시간 투표가 완료되었습니다.\n\n")
+            append("겹치는 시간:\n")
+            overlappingTimes.forEach { time ->
+                append("• $time\n")
+            }
+            append("\n최종 시간 투표로 넘어가시겠습니까?")
+        }
+        
+        androidx.appcompat.app.AlertDialog.Builder(this)
+            .setTitle("최종 시간 투표")
+            .setMessage(message)
+            .setPositiveButton("이동") { _, _ ->
+                hasNavigatedToFinalVote = true
+                
+                lifecycleScope.launch {
+                    try {
+                        // 그룹 상태를 TIME_FINALIZING으로 변경
+                        groupRepository.updateGroupStatus(groupId, "TIME_FINALIZING")
+                        
+                        // 최종 시간 투표 화면으로 이동
+                        val intent = android.content.Intent(this@TimeVoteActivity, FinalTimeVoteActivity::class.java).apply {
+                            putExtra("groupId", groupId)
+                            putExtra("date", dateWithAllVoted)
+                        }
+                        startActivity(intent)
+                        finish()
+                    } catch (e: Exception) {
+                        android.util.Log.e("TimeVoteActivity", "최종 투표 화면 이동 중 오류: ${e.message}", e)
+                        Toast.makeText(this@TimeVoteActivity, "오류가 발생했습니다: ${e.message}", Toast.LENGTH_SHORT).show()
+                    }
+                }
+            }
+            .setNegativeButton("취소", null)
+            .show()
+    }
+    
+    /**
+     * 모든 멤버가 투표했는지 확인 (현재 선택된 날짜 기준)
+     * 최소 하나의 날짜에 모든 멤버가 투표했고, 겹치는 시간이 있으면 최종 투표 화면으로 이동
+     */
+    private suspend fun checkAllDatesVoted() {
+        try {
+            val group = try {
+                groupRepository.getGroupDetail(groupId)
+            } catch (e: CancellationException) {
+                android.util.Log.w("TimeVoteActivity", "그룹 조회 취소됨: ${e.message}")
+                return
+            } catch (e: Exception) {
+                android.util.Log.e("TimeVoteActivity", "그룹 조회 실패: ${e.message}", e)
+                return
+            }
+            
+            val memberUids = group?.memberUids ?: emptyList()
+            
+            if (memberUids.isEmpty()) {
+                return
+            }
+            
+            // 현재 주의 모든 날짜 확인 (월~일, 7일)
+            val tempCal = calendar.clone() as Calendar
+            tempCal.set(Calendar.DAY_OF_WEEK, Calendar.MONDAY)
+            
+            val datesToCheck = mutableListOf<String>()
+            for (i in 0 until 7) {
+                val dateStr = dateFormat.format(tempCal.time)
+                datesToCheck.add(dateStr)
+                tempCal.add(Calendar.DAY_OF_MONTH, 1)
+            }
+            
+            // 최소 하나의 날짜에 모든 멤버가 투표했는지 확인
+            var dateWithAllVoted: String? = null
+            var overlappingTimes: List<String> = emptyList()
+            var hasAllVotedButNoOverlap = false
+            
+            for (dateStr in datesToCheck) {
+                val allVoted = timeVoteRepository.checkAllMembersVoted(groupId, dateStr, memberUids)
+                if (allVoted) {
+                    dateWithAllVoted = dateStr
+                    // 모든 멤버가 투표한 날짜에서 겹치는 시간 확인
+                    val overlapping = timeVoteRepository.getOverlappingTimes(groupId, dateStr, memberUids)
+                    if (overlapping.isNotEmpty()) {
+                        // 시간 형식 변환: "14:00" -> "14시"
+                        overlappingTimes = overlapping.keys.sorted().map { timeStr ->
+                            val hour = timeStr.split(":")[0].toIntOrNull() ?: 0
+                            "${hour}시"
+                        }
+                        break
+                    } else {
+                        // 모든 멤버가 투표했지만 겹치는 시간이 없음
+                        hasAllVotedButNoOverlap = true
+                    }
+                }
+            }
+            
+            // 모든 멤버가 투표한 날짜가 있는 경우 처리
+            if (dateWithAllVoted != null && !hasNavigatedToFinalVote) {
+                // 대기 중 메시지 닫기
+                dismissWaitingDialog()
+                
+                if (overlappingTimes.isNotEmpty()) {
+                    // 겹치는 시간이 있으면 최종 투표 확인 팝업 표시
+                    android.util.Log.d("TimeVoteActivity", "✅ 모든 멤버 투표 완료 확인! 최종 투표 확인 팝업 표시. (날짜: $dateWithAllVoted)")
+                    showFinalVoteConfirmationDialog(dateWithAllVoted, overlappingTimes)
+                } else if (hasAllVotedButNoOverlap) {
+                    // 모든 멤버가 투표했지만 겹치는 시간이 없음
+                    android.util.Log.d("TimeVoteActivity", "⚠️ 모든 멤버 투표 완료했지만 겹치는 시간이 없음")
+                    showNoOverlappingTimeDialog()
+                }
+            }
+        } catch (e: Exception) {
+            android.util.Log.e("TimeVoteActivity", "모든 날짜 투표 확인 중 오류: ${e.message}", e)
+        }
+    }
+    
+    override fun onDestroy() {
+        super.onDestroy()
+        dismissWaitingDialog()
+        currentVoteObserver?.cancel()
+    }
+
+}
+

--- a/app/src/main/res/layout/activity_final_time_vote.xml
+++ b/app/src/main/res/layout/activity_final_time_vote.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/white">
+
+    <!-- 툴바 -->
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="@color/white"
+        app:navigationIcon="@drawable/ic_chevron_left_24"
+        android:elevation="0dp"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <!-- 제목 -->
+    <TextView
+        android:id="@+id/tvTitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="최종 시간 투표"
+        android:textColor="@color/black"
+        android:textStyle="bold"
+        android:textSize="20sp"
+        android:paddingHorizontal="20dp"
+        android:paddingTop="12dp"
+        android:paddingBottom="8dp"
+        app:layout_constraintTop_toBottomOf="@id/toolbar"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <!-- 설명 -->
+    <TextView
+        android:id="@+id/tvDescription"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="모든 멤버가 가능한 시간 중에서 선택해주세요"
+        android:textColor="@color/text_secondary"
+        android:textSize="14sp"
+        android:paddingHorizontal="20dp"
+        android:paddingBottom="16dp"
+        app:layout_constraintTop_toBottomOf="@id/tvTitle"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <!-- 겹치는 시간 리스트 -->
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rvFinalTimes"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:paddingHorizontal="16dp"
+        android:clipToPadding="false"
+        app:layout_constraintTop_toBottomOf="@id/tvDescription"
+        app:layout_constraintBottom_toTopOf="@id/btnSubmitVote"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <!-- 빈 메시지 -->
+    <TextView
+        android:id="@+id/tvEmptyMessage"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="모든 멤버가 겹치는 시간이 없습니다."
+        android:textColor="@color/text_secondary"
+        android:textSize="16sp"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="@id/rvFinalTimes"
+        app:layout_constraintBottom_toBottomOf="@id/rvFinalTimes"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <!-- 투표 버튼 -->
+    <Button
+        android:id="@+id/btnSubmitVote"
+        android:layout_width="0dp"
+        android:layout_height="56dp"
+        android:text="투표하기"
+        android:textColor="@color/white"
+        android:backgroundTint="@color/brand_blue"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        android:visibility="gone"
+        android:layout_margin="16dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>
+

--- a/app/src/main/res/layout/activity_group_detail.xml
+++ b/app/src/main/res/layout/activity_group_detail.xml
@@ -49,17 +49,83 @@
                 android:textStyle="bold"
                 android:textColor="#3B82F6"
                 android:layout_marginTop="8dp"
-                android:layout_marginBottom="32dp"/>
-
-            <Button
-                android:id="@+id/btn_calculate_midpoint"
-                android:layout_width="match_parent"
-                android:layout_height="50dp"
-                android:text="중간값 계산하기"
-                android:backgroundTint="#8B5CF6"
-                android:textSize="16sp"
-                android:textStyle="bold"
                 android:layout_marginBottom="16dp"/>
+
+            <!-- 최종 확정된 일정 표시 블록 -->
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/confirmed_schedule_section"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                android:visibility="gone"
+                app:cardCornerRadius="12dp"
+                app:cardElevation="2dp"
+                app:cardBackgroundColor="@color/white">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="16dp">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="최종 확정된 일정"
+                        android:textSize="16sp"
+                        android:textStyle="bold"
+                        android:textColor="@color/black"
+                        android:layout_marginBottom="8dp"/>
+
+                    <TextView
+                        android:id="@+id/text_confirmed_time"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="일시: 2025년 11월 20일 (수) 오후 2:00"
+                        android:textSize="14sp"
+                        android:textColor="@color/text_secondary"
+                        android:layout_marginBottom="4dp"/>
+
+                    <TextView
+                        android:id="@+id/text_confirmed_place"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="장소: 카페 이름"
+                        android:textSize="14sp"
+                        android:textColor="@color/text_secondary"/>
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <!-- 시간/장소 선택 버튼 -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:layout_marginBottom="16dp">
+
+                <Button
+                    android:id="@+id/btn_time_vote"
+                    android:layout_width="0dp"
+                    android:layout_height="50dp"
+                    android:layout_weight="1"
+                    android:text="시간 투표"
+                    android:backgroundTint="#3B82F6"
+                    android:textSize="16sp"
+                    android:textStyle="bold"
+                    android:layout_marginEnd="8dp"/>
+
+                <Button
+                    android:id="@+id/btn_place_vote"
+                    android:layout_width="0dp"
+                    android:layout_height="50dp"
+                    android:layout_weight="1"
+                    android:text="장소 투표"
+                    android:backgroundTint="#8B5CF6"
+                    android:textSize="16sp"
+                    android:textStyle="bold"
+                    android:layout_marginStart="8dp"
+                    android:enabled="false"/>
+            </LinearLayout>
 
             <Button
                 android:id="@+id/btn_confirm_schedule_now"
@@ -86,46 +152,6 @@
                 android:background="@drawable/bg_input_field"
                 android:padding="8dp"
                 android:layout_marginBottom="32dp"/>
-
-            <LinearLayout
-                android:id="@+id/confirmed_schedule_section"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:padding="16dp"
-                android:background="@drawable/bg_info_box_blue"
-                android:visibility="gone">
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="확정된 약속 정보"
-                    android:textStyle="bold"
-                    android:textColor="#003366"
-                    android:textSize="18sp"
-                    android:layout_marginBottom="8dp"/>
-
-                <TextView
-                    android:id="@+id/text_confirmed_place"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="장소: 미정"
-                    android:textColor="#003366"
-                    android:drawableStart="@drawable/ic_google_calendar"
-                    android:drawablePadding="8dp"
-                    android:textSize="16sp"
-                    android:layout_marginBottom="4dp"/>
-
-                <TextView
-                    android:id="@+id/text_confirmed_time"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="일시: 미정"
-                    android:textColor="#003366"
-                    android:drawableStart="@drawable/ic_calendar_other"
-                    android:drawablePadding="8dp"
-                    android:textSize="16sp"/>
-            </LinearLayout>
 
 
             <TextView

--- a/app/src/main/res/layout/activity_time_vote.xml
+++ b/app/src/main/res/layout/activity_time_vote.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/white"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <!-- 툴바 -->
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="@color/white"
+        app:navigationIcon="@drawable/ic_chevron_left_24"
+        android:elevation="0dp" />
+
+    <TextView
+        android:id="@+id/tvTitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="시간 투표"
+        android:textColor="@color/black"
+        android:textStyle="bold"
+        android:textSize="20sp"
+        android:paddingHorizontal="20dp"
+        android:paddingTop="12dp"
+        android:paddingBottom="8dp" />
+
+    <!-- 상단 주차/날짜 헤더 -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <!--  주차 타이틀 + 이전/다음 버튼 -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical|center_horizontal"
+            android:layout_marginBottom="4dp">
+
+            <ImageView
+                android:id="@+id/btnPrevWeek"
+                android:layout_width="28dp"
+                android:layout_height="28dp"
+                android:src="@drawable/ic_arrow_left_24"
+                android:padding="4dp"
+                android:layout_marginEnd="8dp" />
+
+            <TextView
+                android:id="@+id/tvWeekTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="11월 3째주"
+                android:textStyle="bold"
+                android:textColor="@color/black"
+                android:textSize="18sp" />
+
+            <ImageView
+                android:id="@+id/btnNextWeek"
+                android:layout_width="28dp"
+                android:layout_height="28dp"
+                android:src="@drawable/ic_arrow_right_24"
+                android:padding="4dp"
+                android:layout_marginStart="8dp" />
+        </LinearLayout>
+
+        <!-- 요일 + 날짜 (월~일) -->
+        <LinearLayout
+            android:id="@+id/layoutWeekDays"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="4dp"
+            android:weightSum="7">
+            <!-- 요일 버튼들이 코드에서 동적 추가됨 -->
+        </LinearLayout>
+    </LinearLayout>
+
+    <!-- 시간표 (0시~23시) -->
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/scrollViewTimeSlots"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:fillViewport="true"
+        android:paddingHorizontal="16dp">
+
+        <GridLayout
+            android:id="@+id/gridTimeSlots"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:columnCount="4"
+            android:paddingVertical="12dp"
+            android:alignmentMode="alignMargins"
+            android:useDefaultMargins="true"
+            android:rowOrderPreserved="false" />
+    </androidx.core.widget.NestedScrollView>
+
+    <!-- 하단 버튼 -->
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btnCompleteVote"
+        android:layout_width="match_parent"
+        android:layout_height="56dp"
+        android:text="저장"
+        android:textColor="@color/white"
+        android:backgroundTint="@color/light_gray"
+        android:textSize="16sp" />
+</LinearLayout>
+

--- a/app/src/main/res/layout/item_final_time.xml
+++ b/app/src/main/res/layout/item_final_time.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginVertical="8dp"
+    android:layout_marginHorizontal="16dp"
+    app:cardCornerRadius="12dp"
+    app:cardElevation="2dp"
+    android:clickable="true"
+    android:focusable="true"
+    android:foreground="?attr/selectableItemBackground">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="20dp"
+        android:gravity="center_vertical">
+
+        <TextView
+            android:id="@+id/tvTime"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="14시"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            android:textColor="@color/black" />
+
+        <ImageView
+            android:id="@+id/ivCheck"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:src="@drawable/ic_check_circle_green"
+            android:visibility="gone"
+            app:tint="@color/white" />
+
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>
+


### PR DESCRIPTION
# 시간 투표 기능 구현

## 📋 개요
그룹 생성 후 장소 투표 전에 시간 투표를 진행할 수 있는 기능을 구현했습니다. 사용자들이 가능한 시간을 드래그 앤 드롭으로 선택하고, 모든 멤버의 투표가 완료되면 겹치는 시간 중에서 최종 시간을 결정합니다.

## ✨ 주요 기능

### 1. 시간 투표 화면 (TimeVoteActivity)
- **드래그 앤 드롭 시간 선택**: 그리드 레이아웃에서 가능한 시간을 드래그로 선택
- **다중 날짜 지원**: 한 주간의 여러 날짜에 시간 선택 가능
- **실시간 투표 동기화**: Firestore 리스너를 통해 다른 멤버의 투표 실시간 확인
- **저장 버튼**: 선택한 시간들을 확인 팝업과 함께 저장
- **자동 확정**: 겹치는 시간이 하나만 있을 경우 자동으로 최종 시간 확정

### 2. 최종 시간 투표 화면 (FinalTimeVoteActivity)
- **겹치는 시간 목록 표시**: 모든 멤버가 가능한 시간들을 리스트로 표시
- **최종 시간 선택**: 사용자가 최종 시간을 선택하여 투표
- **자동 시간 확정**: 모든 멤버의 최종 투표 완료 시 자동으로 시간 확정

### 3. 그룹 상태 관리
- `GROUP_CREATED` → `TIME_VOTE_REQUIRED` → `TIME_FINALIZING` → `LOCATION_INPUT_REQUIRED`
- 시간 투표 완료 후 장소 투표 단계로 자동 전환

## 🏗️ 구현 상세

### 새로운 파일
- `TimeVoteActivity.kt`: 시간 투표 메인 화면
- `FinalTimeVoteActivity.kt`: 최종 시간 투표 화면
- `FinalTimeAdapter.kt`: 최종 시간 리스트 어댑터
- `TimeVoteRepository.kt`: 시간 투표 관련 Firestore 작업 처리
- `activity_time_vote.xml`: 시간 투표 화면 레이아웃
- `activity_final_time_vote.xml`: 최종 시간 투표 화면 레이아웃
- `item_final_time.xml`: 최종 시간 리스트 아이템 레이아웃

### 수정된 파일
- `GroupRepository.kt`: 
  - `updateGroupStatus()`: 그룹 상태 업데이트
  - `setFinalTime()`: 최종 시간 확정 및 상태 변경
  - `startVoting()`: 투표 시작 (호스트만 가능)
- `GroupDetailActivity.kt`: 
  - 시간 투표/장소 투표 버튼 추가
  - 그룹 상태에 따른 버튼 활성화/비활성화
  - 최종 확정된 시간 표시
- `activity_group_detail.xml`: 
  - 시간 투표/장소 투표 버튼 추가
  - 최종 확정 시간 표시 섹션 추가

## 🔄 워크플로우

1. **그룹 생성** → `GROUP_CREATED` 상태
2. **시간 투표 시작** → `TIME_VOTE_REQUIRED` 상태
3. **사용자별 시간 선택** → 드래그 앤 드롭으로 가능한 시간 선택
4. **투표 저장** → Firestore에 시간 투표 저장
5. **모든 멤버 투표 완료 확인** → 실시간으로 다른 멤버 투표 확인
6. **겹치는 시간 확인**:
   - **1개**: 자동으로 최종 시간 확정 → `LOCATION_INPUT_REQUIRED` 상태
   - **2개 이상**: 최종 시간 투표 화면으로 이동 → `TIME_FINALIZING` 상태
7. **최종 시간 투표** → 모든 멤버가 최종 시간 선택
8. **시간 확정** → `LOCATION_INPUT_REQUIRED` 상태로 변경
9. **장소 투표 시작** → 장소 투표 버튼 활성화

## 🗄️ Firestore 구조

### 시간 투표 데이터
```
groups/{groupId}/timeVotes/{date}/
  - availableTimes: Map<String, List<String>>  // 시간 -> 투표한 사용자 UID 리스트
  - finalVotes: Map<String, String>            // UID -> 선택한 최종 시간
  - finalVotedUsers: List<String>              // 최종 투표 완료한 사용자 UID 리스트
  - updatedAt: Timestamp
```

### 그룹 문서 업데이트
- `status`: 그룹 상태 (TIME_VOTE_REQUIRED, TIME_FINALIZING, LOCATION_INPUT_REQUIRED)
- `confirmedTime`: 최종 확정된 시간 (Timestamp)

## 🎯 주요 로직

### 겹치는 시간 계산
- 모든 멤버가 투표한 시간 중에서 모든 멤버가 선택한 시간만 필터링
- 투표 수가 멤버 수와 같은 시간만 겹치는 시간으로 판단

### 자동 확정 로직
- 겹치는 시간이 1개만 있을 경우:
  - 자동으로 `GroupRepository.setFinalTime()` 호출
  - 그룹 상태를 `LOCATION_INPUT_REQUIRED`로 변경
  - 자동 확정 팝업 메시지 표시
  - `GroupDetailActivity`로 이동

### 최종 시간 결정
- 최종 투표에서 가장 많이 선택된 시간을 승리 시간으로 결정
- 동점일 경우 첫 번째 시간 선택

## 🐛 버그 수정

1. **WindowLeaked 경고 해결**: 다이얼로그를 변수에 저장하고 `onDestroy`에서 정리
2. **메모리 누수 방지**: 모든 다이얼로그를 Activity 생명주기에 맞춰 관리
3. **Coroutine 스코프 오류 수정**: suspend 함수 호출 시 `lifecycleScope.launch` 사용
4. **Firestore 문서 생성 오류**: `update()` 대신 `set(..., SetOptions.merge())` 사용

## 📱 UI/UX 개선

- 드래그 앤 드롭으로 직관적인 시간 선택
- 실시간 투표 상태 확인
- 다른 멤버 투표 대기 중 메시지 표시
- 겹치는 시간 없을 때 안내 메시지
- 자동 확정 시 명확한 팝업 메시지

## 🔍 테스트 시나리오

1. ✅ 여러 날짜에 시간 선택 후 저장
2. ✅ 모든 멤버 투표 완료 시 최종 투표 화면 이동
3. ✅ 겹치는 시간이 1개일 때 자동 확정
4. ✅ 겹치는 시간이 없을 때 안내 메시지
5. ✅ 최종 시간 투표 후 자동 시간 확정
6. ✅ 그룹 상태 변경 확인
7. ✅ GroupDetailActivity에서 최종 시간 표시

## 📝 참고사항

- 시간 형식: "HH:mm" (예: "14:00")
- 날짜 형식: "yyyy-MM-dd" (예: "2025-11-20")
- 모든 시간 투표는 Firestore에 실시간으로 동기화됨
- 그룹 상태는 서버에서 관리되며 실시간으로 업데이트됨

