### PR TITLE
Feat: 그룹 관리 화면 추가 및 방장 전용 기능 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -114,6 +114,10 @@
                 android:resource="@xml/file_paths" />
         </provider>
 
+        <activity
+            android:name=".ui.groups.GroupManageActivity"
+            android:exported="false" />
+
 
     </application>
 

--- a/app/src/main/java/com/moyeoyo/app/data/repository/GroupRepository.kt
+++ b/app/src/main/java/com/moyeoyo/app/data/repository/GroupRepository.kt
@@ -388,6 +388,47 @@ class GroupRepository @Inject constructor(
     }
 
     /**
+     * ⭐ NEW: 그룹 이름 수정
+     */
+    suspend fun updateGroupName(groupId: String, newName: String): Boolean {
+        return try {
+            groupsCollection.document(groupId)
+                .update("groupName", newName)
+                .await()
+            Log.d(TAG, "updateGroupName SUCCESS: $newName")
+            true
+        } catch (e: Exception) {
+            Log.e(TAG, "updateGroupName FAILED: ${e.message}")
+            false
+        }
+    }
+
+    /**
+     * ⭐ NEW: 확정된 일정 수정
+     */
+    suspend fun updateConfirmedSchedule(
+        groupId: String,
+        confirmedTime: Timestamp,
+        confirmedPlace: Map<String, Any>
+    ): Boolean {
+        return try {
+            groupsCollection.document(groupId)
+                .update(
+                    mapOf(
+                        "confirmedTime" to confirmedTime,
+                        "confirmedPlace" to confirmedPlace
+                    )
+                ).await()
+
+            Log.d(TAG, "updateConfirmedSchedule SUCCESS")
+            true
+        } catch (e: Exception) {
+            Log.e(TAG, "updateConfirmedSchedule FAILED: ${e.message}")
+            false
+        }
+    }
+
+    /**
      * 그룹과 그 하위 컬렉션의 모든 데이터를 삭제합니다.
      */
     suspend fun deleteGroup(groupId: String): Boolean {

--- a/app/src/main/java/com/moyeoyo/app/ui/groups/GroupDetailActivity.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/groups/GroupDetailActivity.kt
@@ -34,6 +34,8 @@ import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.*
 import javax.inject.Inject
+import com.moyeoyo.app.ui.groups.GroupManageActivity
+
 
 @AndroidEntryPoint
 class GroupDetailActivity : AppCompatActivity() {
@@ -90,9 +92,9 @@ class GroupDetailActivity : AppCompatActivity() {
         binding.btnDeleteGroup.setOnClickListener {
             showDeleteGroupConfirmationDialog()
         }
-        binding.btnLeaveGroup.setOnClickListener {
-            showLeaveGroupConfirmationDialog()
-        }
+//        binding.btnLeaveGroup.setOnClickListener {
+//            showLeaveGroupConfirmationDialog()
+//        }
     }
 
     // ---------------------------
@@ -286,9 +288,24 @@ class GroupDetailActivity : AppCompatActivity() {
 
                 displayConfirmedSchedule(group)
 
-                // 삭제/나가기 버튼
-                binding.btnDeleteGroup.visibility = if (isHost) View.VISIBLE else View.GONE
-                binding.btnLeaveGroup.visibility = if (!isHost) View.VISIBLE else View.GONE
+                // 버튼 표시/동작 분기
+                if (isHost) {
+                    // 호스트: "그룹 관리" 버튼만 보이게
+                    binding.btnDeleteGroup.visibility = View.GONE
+                    binding.btnLeaveGroup.visibility = View.VISIBLE
+                    binding.btnLeaveGroup.text = "그룹 관리"
+                    binding.btnLeaveGroup.setOnClickListener {
+                        navigateToGroupManageScreen(group.id, group.groupName)
+                    }
+                } else {
+                    // 일반 멤버: 기존처럼 "그룹 나가기"
+                    binding.btnDeleteGroup.visibility = View.GONE
+                    binding.btnLeaveGroup.visibility = View.VISIBLE
+                    binding.btnLeaveGroup.text = "그룹 나가기"
+                    binding.btnLeaveGroup.setOnClickListener {
+                        showLeaveGroupConfirmationDialog()
+                    }
+                }
 
                 // 상태에 따른 버튼 활성화 제어
                 updateButtonsByStatus(group.status)
@@ -446,6 +463,17 @@ class GroupDetailActivity : AppCompatActivity() {
         val intent = Intent(this, GroupInviteActivity::class.java)
         intent.putExtra("GROUP_ID", groupId)
         intent.putExtra("GROUP_NAME", groupName)
+        startActivity(intent)
+    }
+
+    // ---------------------------
+    //  그룹 관리 화면 이동 (호스트 전용)
+    // ---------------------------
+    private fun navigateToGroupManageScreen(groupId: String, groupName: String) {
+        val intent = Intent(this, GroupManageActivity::class.java).apply {
+            putExtra("GROUP_ID", groupId)
+            putExtra("GROUP_NAME", groupName)
+        }
         startActivity(intent)
     }
 

--- a/app/src/main/java/com/moyeoyo/app/ui/groups/GroupManageActivity.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/groups/GroupManageActivity.kt
@@ -1,0 +1,272 @@
+package com.moyeoyo.app.ui.groups
+
+import android.app.DatePickerDialog
+import android.app.TimePickerDialog
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.viewModels
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import com.google.firebase.Timestamp
+import com.moyeoyo.app.MainActivity
+import com.moyeoyo.app.data.model.Group
+import com.moyeoyo.app.data.repository.GroupRepository
+import com.moyeoyo.app.databinding.ActivityGroupManageBinding
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+import java.util.Calendar
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class GroupManageActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityGroupManageBinding
+
+    @Inject lateinit var groupRepository: GroupRepository
+
+    private lateinit var groupId: String
+    private var originalGroup: Group? = null
+
+    // 일정 수정용 임시 값
+    private var editedTimestamp: Timestamp? = null
+    private var editedPlaceMap: MutableMap<String, Any>? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityGroupManageBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        groupId = intent.getStringExtra("GROUP_ID") ?: run {
+            Toast.makeText(this, "그룹 정보가 없습니다.", Toast.LENGTH_SHORT).show()
+            finish()
+            return
+        }
+
+        setupToolbar()
+        setupClickListeners()
+        loadGroupInfo()
+    }
+
+    private fun setupToolbar() {
+        binding.toolbar.setNavigationOnClickListener { finish() }
+    }
+
+    private fun setupClickListeners() {
+        // 그룹 이름 저장
+        binding.btnSaveGroupName.setOnClickListener {
+            saveGroupName()
+        }
+
+        // 그룹 삭제
+        binding.btnDeleteGroup.setOnClickListener {
+            showDeleteGroupConfirmationDialog()
+        }
+
+// 날짜 선택
+        binding.scheduleSection.fieldDate.setOnClickListener {
+            showDatePicker()
+        }
+
+// 시간 선택
+        binding.scheduleSection.fieldTime.setOnClickListener {
+            showTimePicker()
+        }
+
+// 일정 저장 버튼
+        binding.scheduleSection.btnSaveSchedule.setOnClickListener {
+            saveSchedule()
+        }
+    }
+
+    private fun loadGroupInfo() {
+        lifecycleScope.launch {
+            val group = groupRepository.getGroupById(groupId)
+            if (group == null) {
+                Toast.makeText(this@GroupManageActivity, "그룹 정보를 불러오지 못했습니다.", Toast.LENGTH_SHORT).show()
+                finish()
+                return@launch
+            }
+
+            originalGroup = group
+
+            // 그룹 이름
+            binding.editGroupName.setText(group.groupName)
+
+            // 확정된 일정이 있다면 섹션 표시
+            val hasConfirmedSchedule = group.confirmedTime != null && group.confirmedPlace != null
+            if (hasConfirmedSchedule) {
+                binding.scheduleSection.root.visibility = android.view.View.VISIBLE
+
+                val cal = Calendar.getInstance().apply {
+                    time = group.confirmedTime!!.toDate()
+                }
+
+                // 날짜/시간 표시
+                val dateStr = String.format(
+                    "%04d-%02d-%02d",
+                    cal.get(Calendar.YEAR),
+                    cal.get(Calendar.MONTH) + 1,
+                    cal.get(Calendar.DAY_OF_MONTH)
+                )
+                val timeStr = String.format(
+                    "%02d:%02d",
+                    cal.get(Calendar.HOUR_OF_DAY),
+                    cal.get(Calendar.MINUTE)
+                )
+
+                binding.scheduleSection.fieldDate.setText(dateStr)
+                binding.scheduleSection.fieldTime.setText(timeStr)
+
+                // 장소 이름
+                val placeName = group.confirmedPlace?.get("name") as? String
+                    ?: group.confirmedPlace?.get("address") as? String
+                    ?: ""
+                binding.scheduleSection.editPlaceName.setText(placeName)
+
+                editedTimestamp = group.confirmedTime
+                editedPlaceMap = (group.confirmedPlace as? MutableMap<String, Any>)?.toMutableMap()
+                    ?: mutableMapOf()
+            } else {
+                binding.scheduleSection.root.visibility = android.view.View.GONE
+            }
+        }
+    }
+
+    // ---------------------------
+    // 그룹 이름 저장
+    // ---------------------------
+    private fun saveGroupName() {
+        val newName = binding.editGroupName.text.toString().trim()
+        if (newName.isEmpty()) {
+            Toast.makeText(this, "그룹 이름을 입력해주세요.", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        lifecycleScope.launch {
+            val success = groupRepository.updateGroupName(groupId, newName)
+            if (success) {
+                Toast.makeText(this@GroupManageActivity, "그룹 이름을 수정했습니다.", Toast.LENGTH_SHORT).show()
+            } else {
+                Toast.makeText(this@GroupManageActivity, "그룹 이름 수정에 실패했습니다.", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    // ---------------------------
+    // 일정 수정 (날짜/시간)
+    // ---------------------------
+    private fun showDatePicker() {
+        val cal = Calendar.getInstance()
+        editedTimestamp?.let { cal.time = it.toDate() }
+
+        DatePickerDialog(
+            this,
+            { _, year, month, dayOfMonth ->
+                val picked = Calendar.getInstance().apply {
+                    set(year, month, dayOfMonth)
+                    // 시간은 기존 값 유지
+                    val hour = cal.get(Calendar.HOUR_OF_DAY)
+                    val minute = cal.get(Calendar.MINUTE)
+                    set(Calendar.HOUR_OF_DAY, hour)
+                    set(Calendar.MINUTE, minute)
+                }
+                editedTimestamp = Timestamp(picked.time)
+                val dateStr = String.format("%04d-%02d-%02d", year, month + 1, dayOfMonth)
+                binding.scheduleSection.fieldDate.setText(dateStr)
+            },
+            cal.get(Calendar.YEAR),
+            cal.get(Calendar.MONTH),
+            cal.get(Calendar.DAY_OF_MONTH)
+        ).show()
+    }
+
+    private fun showTimePicker() {
+        val cal = Calendar.getInstance()
+        editedTimestamp?.let { cal.time = it.toDate() }
+
+        TimePickerDialog(
+            this,
+            { _, hourOfDay, minute ->
+                val picked = Calendar.getInstance().apply {
+                    if (editedTimestamp != null) {
+                        time = editedTimestamp!!.toDate()
+                    }
+                    set(Calendar.HOUR_OF_DAY, hourOfDay)
+                    set(Calendar.MINUTE, minute)
+                }
+                editedTimestamp = Timestamp(picked.time)
+                val timeStr = String.format("%02d:%02d", hourOfDay, minute)
+                binding.scheduleSection.fieldTime.setText(timeStr)
+            },
+            cal.get(Calendar.HOUR_OF_DAY),
+            cal.get(Calendar.MINUTE),
+            true
+        ).show()
+    }
+
+    // ---------------------------
+    // 일정 저장
+    // ---------------------------
+    private fun saveSchedule() {
+        val currentGroup = originalGroup
+        if (currentGroup?.confirmedTime == null || currentGroup.confirmedPlace == null) {
+            Toast.makeText(this, "확정된 일정이 없는 그룹입니다.", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        val newTimestamp = editedTimestamp
+        val placeName = binding.scheduleSection.editPlaceName.text.toString().trim()
+
+        if (newTimestamp == null) {
+            Toast.makeText(this, "날짜와 시간을 선택해주세요.", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        if (placeName.isEmpty()) {
+            Toast.makeText(this, "장소 이름을 입력해주세요.", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        val placeMap = (editedPlaceMap ?: mutableMapOf()).apply {
+            this["name"] = placeName
+        }
+
+        lifecycleScope.launch {
+            val success = groupRepository.updateConfirmedSchedule(groupId, newTimestamp, placeMap)
+            if (success) {
+                Toast.makeText(this@GroupManageActivity, "일정을 수정했습니다.", Toast.LENGTH_SHORT).show()
+            } else {
+                Toast.makeText(this@GroupManageActivity, "일정 수정에 실패했습니다.", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    // ---------------------------
+    // 그룹 삭제
+    // ---------------------------
+    private fun showDeleteGroupConfirmationDialog() {
+        AlertDialog.Builder(this)
+            .setTitle("그룹 삭제")
+            .setMessage("정말로 이 그룹을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.")
+            .setPositiveButton("삭제") { _, _ ->
+                deleteGroup()
+            }
+            .setNegativeButton("취소", null)
+            .show()
+    }
+
+    private fun deleteGroup() {
+        lifecycleScope.launch {
+            val success = groupRepository.deleteGroup(groupId)
+            if (success) {
+                Toast.makeText(this@GroupManageActivity, "그룹을 삭제했습니다.", Toast.LENGTH_LONG).show()
+                startActivity(Intent(this@GroupManageActivity, MainActivity::class.java))
+                finishAffinity()
+            } else {
+                Toast.makeText(this@GroupManageActivity, "그룹 삭제에 실패했습니다.", Toast.LENGTH_LONG).show()
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_group_manage.xml
+++ b/app/src/main/res/layout/activity_group_manage.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/white">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/white"
+        android:elevation="2dp">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="@color/white"
+            app:navigationIcon="@drawable/ic_chevron_left_24"
+            app:title="그룹 관리"
+            app:titleTextColor="@color/black"/>
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:padding="20dp"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <!-- 그룹 이름 수정 -->
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="그룹 이름"
+                android:textSize="14sp"
+                android:textColor="@color/text_secondary"/>
+
+            <EditText
+                android:id="@+id/editGroupName"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:background="@drawable/bg_input_field"
+                android:padding="10dp"
+                android:textSize="16sp"
+                android:hint="그룹 이름을 입력하세요"/>
+
+            <Button
+                android:id="@+id/btnSaveGroupName"
+                android:layout_width="match_parent"
+                android:layout_height="48dp"
+                android:layout_marginTop="8dp"
+                android:text="이름 저장"
+                android:textStyle="bold"
+                android:backgroundTint="#3B82F6"/>
+
+            <!-- 확정 일정 섹션 (있을 때만 보임) -->
+            <include
+                android:id="@+id/scheduleSection"
+                layout="@layout/view_group_manage_schedule_section"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"/>
+
+            <!-- 그룹 삭제 -->
+            <Button
+                android:id="@+id/btnDeleteGroup"
+                android:layout_width="match_parent"
+                android:layout_height="48dp"
+                android:layout_marginTop="32dp"
+                android:backgroundTint="@color/light_gray_bg"
+                android:text="그룹 삭제"
+                android:textColor="@color/black"
+                android:textStyle="bold"/>
+        </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/view_group_manage_schedule_section.xml
+++ b/app/src/main/res/layout/view_group_manage_schedule_section.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/root"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="12dp"
+    android:background="@drawable/bg_card_gray">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="확정된 일정 수정"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        android:textColor="@color/black"
+        android:layout_marginBottom="8dp"/>
+
+    <!-- 날짜 -->
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="날짜"
+        android:textSize="14sp"
+        android:textColor="@color/text_secondary"/>
+
+    <EditText
+        android:id="@+id/fieldDate"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:focusable="false"
+        android:clickable="true"
+        android:background="@drawable/bg_input_field"
+        android:padding="10dp"
+        android:hint="YYYY-MM-DD"/>
+
+    <!-- 시간 -->
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:text="시간"
+        android:textSize="14sp"
+        android:textColor="@color/text_secondary"/>
+
+    <EditText
+        android:id="@+id/fieldTime"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:focusable="false"
+        android:clickable="true"
+        android:background="@drawable/bg_input_field"
+        android:padding="10dp"
+        android:hint="HH:mm"/>
+
+    <!-- 장소 이름 -->
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:text="장소"
+        android:textSize="14sp"
+        android:textColor="@color/text_secondary"/>
+
+    <EditText
+        android:id="@+id/editPlaceName"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:background="@drawable/bg_input_field"
+        android:padding="10dp"
+        android:hint="장소 이름을 입력하세요"/>
+
+    <Button
+        android:id="@+id/btnSaveSchedule"
+        android:layout_width="match_parent"
+        android:layout_height="44dp"
+        android:layout_marginTop="16dp"
+        android:text="일정 저장"
+        android:textStyle="bold"
+        android:backgroundTint="#3B82F6"/>
+</LinearLayout>


### PR DESCRIPTION
이번 PR에서는 방장 전용 그룹 관리 기능과 그룹 디테일 화면의 행동 로직을 개선하였습니다.

추가된 기능

1. 그룹 관리 화면 추가 (GroupManageActivity)
- 방장만 접근 가능한 그룹 관리 전용 화면 추가
- 그룹 이름 수정 기능 구현
- 그룹 삭제 기능 구현
- 확정된 일정(시간/장소)이 있을 경우 수정 기능 제공
- view_group_manage_schedule_section.xml 추가 및 ViewBinding 연동

2. 그룹 디테일 화면(GroupDetailActivity) 개선
- 방장에게는 "그룹 나가기" 대신 **"그룹 관리"** 버튼 표시
- 일반 멤버는 기존처럼 그룹 나가기 버튼만 노출
- 관리 버튼 클릭 시 GroupManageActivity로 화면 이동

3. GroupRepository 기능 확장
- updateGroupName(): 그룹 이름 수정 기능 추가
- updateConfirmedSchedule(): 확정된 일정 수정 기능 추가
- 기존 CRUD 및 일정 확정 로직과 호환되도록 구성

테스트 결과
- 방장/일반 멤버 분기 정상 작동 확인
- 그룹 이름 수정 → GroupDetailActivity 복귀 시 정상 반영
- 일정 수정 시 Firestore 업데이트 정상 작동 확인
- 그룹 삭제 시 메인 화면 이동 정상 작동

추가 확인 요청 사항
- 일정 수정 화면에 추가 UI 요소 필요 여부
- 방장 전용 기능 확장(예: 멤버 역할 관리) 계획 여부

