### PR TITLE
Fix: 시간 투표 시스템 개선

### DIFF
--- a/app/src/main/java/com/moyeoyo/app/data/repository/TimeVoteRepository.kt
+++ b/app/src/main/java/com/moyeoyo/app/data/repository/TimeVoteRepository.kt
@@ -349,5 +349,32 @@ class TimeVoteRepository @Inject constructor(
 
         awaitClose { listenerRegistration.remove() }
     }
+
+    /**
+     * 최종 시간 투표 데이터 초기화 (만장일치 실패 시 사용)
+     * @param groupId 그룹 ID
+     * @param date 날짜
+     */
+    suspend fun clearFinalVotes(groupId: String, date: String) {
+        try {
+            val finalVoteRef = db.collection("groups")
+                .document(groupId)
+                .collection("timeVotes")
+                .document(date)
+
+            // finalVotes와 finalVotedUsers 필드 삭제
+            finalVoteRef.update(
+                mapOf(
+                    "finalVotes" to FieldValue.delete(),
+                    "finalVotedUsers" to FieldValue.delete()
+                )
+            ).await()
+
+            Log.d(TAG, "✅ 최종 시간 투표 데이터 초기화 완료: groupId=$groupId, date=$date")
+        } catch (e: Exception) {
+            Log.e(TAG, "❌ 최종 시간 투표 데이터 초기화 실패: ${e.message}", e)
+            throw e
+        }
+    }
 }
 

--- a/app/src/main/java/com/moyeoyo/app/ui/groups/VoteTabHandler.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/groups/VoteTabHandler.kt
@@ -17,6 +17,7 @@ import com.moyeoyo.app.ui.place.FinalCandidate
 import com.moyeoyo.app.ui.place.FinalCandidateAdapter
 import com.moyeoyo.app.ui.place.FinalVoteViewModel
 import com.moyeoyo.app.ui.time.FinalTimeAdapter
+import com.moyeoyo.app.ui.time.FinalTimeItem
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
@@ -264,9 +265,382 @@ class VoteTabHandler(
         }
         
         recyclerFinalTimes.adapter = finalTimeAdapter
-        finalTimeAdapter.submitList(overlappingTimes.map { it.first })
+        // ⭐ 수정: FinalTimeItem 리스트로 변환 (날짜 정보 포함)
+        finalTimeAdapter.submitList(overlappingTimes.map { 
+            FinalTimeItem(it.first, finalTimeDate ?: "") 
+        })
         
         // 최종 투표 섹션 숨기기
+        //
+        //import android.view.View
+        //import android.widget.Button
+        //import android.widget.TextView
+        //import android.widget.Toast
+        //import androidx.lifecycle.LifecycleCoroutineScope
+        //import androidx.recyclerview.widget.LinearLayoutManager
+        //import androidx.recyclerview.widget.RecyclerView
+        //import com.google.firebase.Timestamp
+        //import com.google.firebase.auth.FirebaseAuth
+        //import com.moyeoyo.app.R
+        //import com.moyeoyo.app.data.model.NearbyPlace
+        //import com.moyeoyo.app.data.repository.GroupRepository
+        //import com.moyeoyo.app.data.repository.TimeVoteRepository
+        //import com.moyeoyo.app.ui.place.FinalCandidate
+        //import com.moyeoyo.app.ui.place.FinalCandidateAdapter
+        //import com.moyeoyo.app.ui.place.FinalVoteViewModel
+        //import com.moyeoyo.app.ui.time.FinalTimeAdapter
+        //import kotlinx.coroutines.flow.collectLatest
+        //import kotlinx.coroutines.launch
+        //import java.text.SimpleDateFormat
+        //import java.util.Calendar
+        //import java.util.Locale
+        //import javax.inject.Inject
+        //
+        ///**
+        // * GroupDetailActivity의 투표 탭 관련 로직을 처리하는 클래스
+        // */
+        //class VoteTabHandler(
+        //    private val activity: GroupDetailActivity,
+        //    private val lifecycleScope: LifecycleCoroutineScope,
+        //    private val groupId: String,
+        //    private val groupName: String,
+        //    private val voteViewModel: FinalVoteViewModel,
+        //    private val groupRepository: GroupRepository,
+        //    private val timeVoteRepository: TimeVoteRepository,
+        //    private val auth: FirebaseAuth
+        //) {
+        //    // UI 요소
+        //    private lateinit var recyclerFinalCandidates: RecyclerView
+        //    private lateinit var btnSubmitVote: Button
+        //    private lateinit var finalVoteAdapter: FinalCandidateAdapter
+        //    private val finalCandidates = mutableListOf<FinalCandidate>()
+        //    private var selectedCandidate: FinalCandidate? = null
+        //
+        //    // 시간 최종투표 관련
+        //    private lateinit var recyclerFinalTimes: RecyclerView
+        //    private lateinit var btnSubmitTimeVote: Button
+        //    private lateinit var finalTimeAdapter: FinalTimeAdapter
+        //    private var selectedTime: String? = null
+        //    private var finalTimeDate: String? = null
+        //    private var layoutFinalTimeVote: View? = null
+        //    private val overlappingTimes = mutableListOf<Pair<String, Int>>()
+        //
+        //    // 상태
+        //    private var isVoteTabInitialized = false
+        //    private var isTimeVoteInitialized = false
+        //
+        //    // 콜백
+        //    var onTimeVoteCompleted: ((String, String) -> Unit)? = null
+        //    var onPlaceVoteCompleted: ((NearbyPlace) -> Unit)? = null
+        //    var onHideVoteUI: (() -> Unit)? = null
+        //
+        //    fun bindVoteTab(view: View) {
+        //        recyclerFinalCandidates = view.findViewById<RecyclerView>(R.id.rvFinalCandidates)
+        //        btnSubmitVote = view.findViewById<Button>(R.id.btnSubmitVote)
+        //        recyclerFinalCandidates.layoutManager = LinearLayoutManager(activity)
+        //
+        //        // 시간 최종 투표 UI
+        //        layoutFinalTimeVote = view.findViewById<View>(R.id.layoutFinalTimeVote)
+        //        recyclerFinalTimes = view.findViewById<RecyclerView>(R.id.rvFinalTimes)
+        //        btnSubmitTimeVote = view.findViewById<Button>(R.id.btnSubmitTimeVote)
+        //        recyclerFinalTimes.layoutManager = LinearLayoutManager(activity)
+        //
+        //        // 위치 필터 버튼
+        //        val btnFilterLocation = view.findViewById<View>(R.id.btnFilterLocation)
+        //        btnFilterLocation.setOnClickListener {
+        //            activity.startLocationInput()
+        //        }
+        //
+        //        // 시간 버튼
+        //        val btnFilterTime = view.findViewById<View>(R.id.btnFilterTime)
+        //        btnFilterTime.setOnClickListener {
+        //            startFinalTimeVote()
+        //        }
+        //
+        //        // 장소 투표 어댑터 설정
+        //        finalVoteAdapter = FinalCandidateAdapter { candidate ->
+        //            selectedCandidate = if (selectedCandidate == candidate) {
+        //                null
+        //            } else {
+        //                candidate
+        //            }
+        //
+        //            if (selectedCandidate != null) {
+        //                voteViewModel.calculateTransitTimeForPlace(candidate.place)
+        //            } else {
+        //                voteViewModel.calculateTransitTimeForPlace(candidate.place)
+        //            }
+        //
+        //            finalCandidates.forEachIndexed { index, item ->
+        //                finalCandidates[index] = item.copy(isSelected = item == selectedCandidate)
+        //            }
+        //            finalVoteAdapter.submitList(finalCandidates.toList())
+        //            btnSubmitVote.visibility = if (selectedCandidate != null) View.VISIBLE else View.GONE
+        //        }
+        //
+        //        recyclerFinalCandidates.adapter = finalVoteAdapter
+        //
+        //        if (!isVoteTabInitialized) {
+        //            observeVoteViewModel()
+        //            startVoteLoading()
+        //            checkTimeVoteStatus()
+        //            isVoteTabInitialized = true
+        //        }
+        //
+        //        btnSubmitVote.setOnClickListener {
+        //            val candidate = selectedCandidate
+        //            if (candidate == null) {
+        //                Toast.makeText(activity, "장소를 선택해주세요.", Toast.LENGTH_SHORT).show()
+        //                return@setOnClickListener
+        //            }
+        //            voteViewModel.submitVote(groupId, candidate.place.placeId)
+        //        }
+        //
+        //        btnSubmitTimeVote.setOnClickListener {
+        //            selectedTime?.let { time ->
+        //                submitFinalTimeVote(time)
+        //            } ?: run {
+        //                Toast.makeText(activity, "시간을 선택해주세요.", Toast.LENGTH_SHORT).show()
+        //            }
+        //        }
+        //    }
+        //
+        //    private fun startVoteLoading() {
+        //        voteViewModel.startListeningToVoteStatus(groupId)
+        //        voteViewModel.loadAllUserRankingsAndCreateCandidates(groupId)
+        //    }
+        //
+        //    private fun observeVoteViewModel() {
+        //        voteViewModel.finalCandidates.observe(activity) { candidates ->
+        //            if (candidates.isEmpty()) {
+        //                finalCandidates.clear()
+        //                finalVoteAdapter.submitList(emptyList())
+        //                return@observe
+        //            }
+        //
+        //            finalCandidates.clear()
+        //            finalCandidates.addAll(candidates)
+        //            finalVoteAdapter.submitList(candidates.toList())
+        //        }
+        //
+        //        voteViewModel.transitTimes.observe(activity) { transitTimes ->
+        //            finalVoteAdapter.updateTransitTimes(transitTimes)
+        //        }
+        //
+        //        voteViewModel.voteSuccess.observe(activity) { success ->
+        //            if (success) {
+        //                Toast.makeText(activity, "투표를 완료했습니다.", Toast.LENGTH_SHORT).show()
+        //            }
+        //        }
+        //
+        //        voteViewModel.error.observe(activity) { msg ->
+        //            msg?.let { Toast.makeText(activity, it, Toast.LENGTH_SHORT).show() }
+        //        }
+        //
+        //        voteViewModel.saveComplete.observe(activity) { saved ->
+        //            if (saved) {
+        //                android.util.Log.d("VoteTabHandler", "✅ 후보 저장 완료")
+        //            }
+        //        }
+        //
+        //        voteViewModel.winningPlace.observe(activity) { place ->
+        //            place?.let {
+        //                onPlaceVoteCompleted?.invoke(it)
+        //            }
+        //        }
+        //    }
+        //
+        //    private fun checkTimeVoteStatus() {
+        //        lifecycleScope.launch {
+        //            val group = groupRepository.getGroupById(groupId)
+        //            if (group?.status == "TIME_FINALIZING") {
+        //                startFinalTimeVote()
+        //            }
+        //        }
+        //    }
+        //
+        //    private fun startFinalTimeVote() {
+        //        lifecycleScope.launch {
+        //            try {
+        //                val group = groupRepository.getGroupById(groupId)
+        //                val memberUids = group?.memberUids ?: emptyList()
+        //
+        //                if (memberUids.isEmpty()) {
+        //                    Toast.makeText(activity, "멤버 정보를 불러올 수 없습니다.", Toast.LENGTH_SHORT).show()
+        //                    return@launch
+        //                }
+        //
+        //                // 현재 주의 모든 날짜 확인
+        //                val calendar = Calendar.getInstance()
+        //                calendar.set(Calendar.DAY_OF_WEEK, Calendar.MONDAY)
+        //                val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+        //
+        //                val datesToCheck = mutableListOf<String>()
+        //                for (i in 0 until 7) {
+        //                    val dateStr = dateFormat.format(calendar.time)
+        //                    datesToCheck.add(dateStr)
+        //                    calendar.add(Calendar.DAY_OF_MONTH, 1)
+        //                }
+        //
+        //                // 모든 멤버가 투표한 날짜 찾기
+        //                var dateWithAllVoted: String? = null
+        //                for (dateStr in datesToCheck) {
+        //                    val allVoted = timeVoteRepository.checkAllMembersVoted(groupId, dateStr, memberUids)
+        //                    if (allVoted) {
+        //                        dateWithAllVoted = dateStr
+        //                        break
+        //                    }
+        //                }
+        //
+        //                if (dateWithAllVoted == null) {
+        //                    // 아직 모든 멤버가 투표하지 않았으면 TimeVoteActivity로 이동
+        //                    val intent = android.content.Intent(activity, com.moyeoyo.app.ui.time.TimeVoteActivity::class.java).apply {
+        //                        putExtra("groupId", groupId)
+        //                    }
+        //                    activity.startActivity(intent)
+        //                    return@launch
+        //                }
+        //
+        //                // 겹치는 시간 가져오기
+        //                val overlapping = timeVoteRepository.getOverlappingTimes(groupId, dateWithAllVoted, memberUids)
+        //
+        //                if (overlapping.isEmpty()) {
+        //                    Toast.makeText(activity, "모든 멤버가 겹치는 시간이 없습니다.", Toast.LENGTH_LONG).show()
+        //                    return@launch
+        //                }
+        //
+        //                // 시간 최종투표 UI 표시
+        //                finalTimeDate = dateWithAllVoted
+        //                showFinalTimeVoteUI(overlapping.toList().sortedByDescending { it.second })
+        //            } catch (e: Exception) {
+        //                Toast.makeText(activity, "오류 발생: ${e.message}", Toast.LENGTH_SHORT).show()
+        //            }
+        //        }
+        //    }
+        //
+        //    private fun showFinalTimeVoteUI(overlappingTimesList: List<Pair<String, Int>>) {
+        //        layoutFinalTimeVote?.visibility = View.VISIBLE
+        //
+        //        overlappingTimes.clear()
+        //        overlappingTimes.addAll(overlappingTimesList)
+        //
+        //        finalTimeAdapter = FinalTimeAdapter { time ->
+        //            selectedTime = if (selectedTime == time) {
+        //                null
+        //            } else {
+        //                time
+        //            }
+        //
+        //            finalTimeAdapter.updateSelection(selectedTime)
+        //            btnSubmitTimeVote.visibility = if (selectedTime != null) View.VISIBLE else View.GONE
+        //        }
+        //
+        //        recyclerFinalTimes.adapter = finalTimeAdapter
+        //        finalTimeAdapter.submitList(overlappingTimes.map { it.first })
+        //
+        //        // 최종 투표 섹션 숨기기
+        //        recyclerFinalCandidates.visibility = View.GONE
+        //        btnSubmitVote.visibility = View.GONE
+        //
+        //        // 최종 투표 관찰 시작
+        //        if (!isTimeVoteInitialized) {
+        //            observeTimeFinalization()
+        //            isTimeVoteInitialized = true
+        //        }
+        //    }
+        //
+        //    private fun submitFinalTimeVote(time: String) {
+        //        val uid = auth.currentUser?.uid ?: return
+        //        finalTimeDate ?: return
+        //
+        //        lifecycleScope.launch {
+        //            try {
+        //                timeVoteRepository.voteFinalTime(groupId, finalTimeDate!!, time, uid)
+        //                Toast.makeText(activity, "투표가 저장되었습니다 ✅", Toast.LENGTH_SHORT).show()
+        //            } catch (e: Exception) {
+        //                Toast.makeText(activity, "투표 저장 중 오류 발생: ${e.message}", Toast.LENGTH_SHORT).show()
+        //            }
+        //        }
+        //    }
+        //
+        //    private fun observeTimeFinalization() {
+        //        finalTimeDate?.let { date ->
+        //            lifecycleScope.launch {
+        //                try {
+        //                    val group = groupRepository.getGroupById(groupId)
+        //                    val memberUids = group?.memberUids ?: emptyList()
+        //
+        //                    if (memberUids.isEmpty()) return@launch
+        //
+        //                    timeVoteRepository.observeFinalVotes(groupId, date).collectLatest { finalVotedUsers ->
+        //                        val allVoted = memberUids.all { it in finalVotedUsers }
+        //
+        //                        if (allVoted && finalVotedUsers.isNotEmpty()) {
+        //                            val finalVotes = timeVoteRepository.getFinalVotes(groupId, date)
+        //                            val finalTime = if (finalVotes.isNotEmpty()) {
+        //                                val voteCounts = finalVotes.groupingBy { it }.eachCount()
+        //                                voteCounts.maxByOrNull { it.value }?.key ?: overlappingTimes.firstOrNull()?.first
+        //                            } else {
+        //                                overlappingTimes.firstOrNull()?.first
+        //                            }
+        //
+        //                            if (finalTime == null) {
+        //                                android.util.Log.e("VoteTabHandler", "최종 시간을 결정할 수 없습니다.")
+        //                                return@collectLatest
+        //                            }
+        //
+        //                            val success = groupRepository.setFinalTime(groupId, date, finalTime)
+        //
+        //                            if (success) {
+        //                                groupRepository.updateGroupStatus(groupId, "LOCATION_INPUT_REQUIRED")
+        //                                showWinningTimeDialog(finalTime, date)
+        //                                onTimeVoteCompleted?.invoke(date, finalTime)
+        //
+        //                                // 시간 투표 완료 후 장소 투표 UI 다시 표시
+        //                                layoutFinalTimeVote?.visibility = View.GONE
+        //                                recyclerFinalCandidates.visibility = View.VISIBLE
+        //                                btnSubmitVote.visibility = View.GONE
+        //                            } else {
+        //                                Toast.makeText(activity, "시간 확정에 실패했습니다.", Toast.LENGTH_SHORT).show()
+        //                            }
+        //                        }
+        //                    }
+        //                } catch (e: Exception) {
+        //                    android.util.Log.e("VoteTabHandler", "최종 투표 관찰 중 오류: ${e.message}", e)
+        //                }
+        //            }
+        //        }
+        //    }
+        //
+        //    private fun showWinningTimeDialog(time: String, date: String) {
+        //        lifecycleScope.launch {
+        //            val group = groupRepository.getGroupById(groupId)
+        //            val name = group?.groupName ?: groupName
+        //
+        //            val dateFormat = SimpleDateFormat("yyyy년 MM월 dd일 (E)", Locale.KOREA)
+        //            val dateObj = SimpleDateFormat("yyyy-MM-dd", Locale.KOREA).parse(date)
+        //            val formattedDate = dateObj?.let { dateFormat.format(it) } ?: date
+        //
+        //            android.app.AlertDialog.Builder(activity)
+        //                .setTitle("최종 약속 시간 확정")
+        //                .setMessage("최종 약속 일시는 \"${formattedDate} ${time}\"로 선정되었습니다.\n이제 장소 투표를 진행할 수 있습니다.")
+        //                .setPositiveButton("확인", null)
+        //                .setCancelable(false)
+        //                .show()
+        //        }
+        //    }
+        //
+        //    fun hideAllVoteUI() {
+        //        layoutFinalTimeVote?.visibility = View.GONE
+        //        recyclerFinalCandidates.visibility = View.GONE
+        //        btnSubmitVote.visibility = View.GONE
+        //        btnSubmitTimeVote.visibility = View.GONE
+        //
+        //        // 초기 버튼 컨테이너도 숨기기
+        //        activity.findViewById<View>(R.id.layoutInitialButtons)?.visibility = View.GONE
+        //        onHideVoteUI?.invoke()
+        //    }
+        //}
         recyclerFinalCandidates.visibility = View.GONE
         btnSubmitVote.visibility = View.GONE
 

--- a/app/src/main/java/com/moyeoyo/app/ui/time/FinalTimeAdapter.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/time/FinalTimeAdapter.kt
@@ -10,9 +10,14 @@ import androidx.recyclerview.widget.RecyclerView
 import com.moyeoyo.app.R
 import com.moyeoyo.app.databinding.ItemFinalTimeBinding
 
+data class FinalTimeItem(
+    val time: String,
+    val date: String
+)
+
 class FinalTimeAdapter(
     private val onTimeClick: (String) -> Unit
-) : ListAdapter<String, FinalTimeAdapter.ViewHolder>(TimeDiffCallback()) {
+) : ListAdapter<FinalTimeItem, FinalTimeAdapter.ViewHolder>(TimeDiffCallback()) {
 
     private var selectedTime: String? = null
 
@@ -35,7 +40,7 @@ class FinalTimeAdapter(
         
         // 이전 선택 항목과 현재 선택 항목 업데이트
         currentList.forEachIndexed { index, item ->
-            if (item == previousSelected || item == selectedTime) {
+            if (item.time == previousSelected || item.time == selectedTime) {
                 notifyItemChanged(index)
             }
         }
@@ -45,10 +50,18 @@ class FinalTimeAdapter(
         private val binding: ItemFinalTimeBinding
     ) : RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(time: String) {
-            binding.tvTime.text = time.replace(":00", "시")
+        fun bind(item: FinalTimeItem) {
+            // 날짜 포맷팅
+            val dateFormat = java.text.SimpleDateFormat("yyyy-MM-dd", java.util.Locale.KOREA)
+            val dateDisplayFormat = java.text.SimpleDateFormat("yyyy년 MM월 dd일 (E)", java.util.Locale.KOREA)
+            val dateObj = dateFormat.parse(item.date)
+            val formattedDate = dateObj?.let { dateDisplayFormat.format(it) } ?: item.date
             
-            val isSelected = time == selectedTime
+            // 날짜와 시간을 함께 표시
+            val timeDisplay = item.time.replace(":00", "시")
+            binding.tvTime.text = "$formattedDate $timeDisplay"
+            
+            val isSelected = item.time == selectedTime
             binding.root.isSelected = isSelected
             
             // 선택 상태에 따라 배경색 및 체크 아이콘 변경
@@ -71,17 +84,17 @@ class FinalTimeAdapter(
             }
             
             binding.root.setOnClickListener {
-                onTimeClick(time)
+                onTimeClick(item.time)
             }
         }
     }
 
-    private class TimeDiffCallback : DiffUtil.ItemCallback<String>() {
-        override fun areItemsTheSame(oldItem: String, newItem: String): Boolean {
-            return oldItem == newItem
+    private class TimeDiffCallback : DiffUtil.ItemCallback<FinalTimeItem>() {
+        override fun areItemsTheSame(oldItem: FinalTimeItem, newItem: FinalTimeItem): Boolean {
+            return oldItem.time == newItem.time && oldItem.date == newItem.date
         }
 
-        override fun areContentsTheSame(oldItem: String, newItem: String): Boolean {
+        override fun areContentsTheSame(oldItem: FinalTimeItem, newItem: FinalTimeItem): Boolean {
             return oldItem == newItem
         }
     }

--- a/app/src/main/java/com/moyeoyo/app/ui/time/FinalTimeVoteActivity.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/time/FinalTimeVoteActivity.kt
@@ -125,8 +125,10 @@ class FinalTimeVoteActivity : AppCompatActivity() {
                 overlappingTimes.clear()
                 overlappingTimes.addAll(overlapping.toList().sortedByDescending { it.second })
                 
-                // 어댑터에 데이터 전달
-                adapter.submitList(overlappingTimes.map { it.first })
+                // 어댑터에 데이터 전달 (날짜 정보 포함)
+                adapter.submitList(overlappingTimes.map { 
+                    com.moyeoyo.app.ui.time.FinalTimeItem(it.first, date) 
+                })
                 
                 binding.tvEmptyMessage.visibility = View.GONE
                 binding.rvFinalTimes.visibility = View.VISIBLE
@@ -155,35 +157,41 @@ class FinalTimeVoteActivity : AppCompatActivity() {
                     val allVoted = memberUids.all { it in finalVotedUsers }
                     
                     if (allVoted && finalVotedUsers.isNotEmpty()) {
-                        android.util.Log.d("FinalTimeVoteActivity", "✅ 모든 멤버 최종 투표 완료! 시간 확정합니다.")
+                        android.util.Log.d("FinalTimeVoteActivity", "✅ 모든 멤버 최종 투표 완료! 만장일치 검사 시작.")
                         
-                        // 최종 시간 가져오기: 최종 투표에서 가장 많이 선택된 시간
+                        // ⭐ 핵심 수정: 만장일치 검사
                         val finalVotes = timeVoteRepository.getFinalVotes(groupId, date)
-                        val finalTime = if (finalVotes.isNotEmpty()) {
-                            // 최종 투표에서 가장 많이 선택된 시간 찾기
-                            val voteCounts = finalVotes.groupingBy { it }.eachCount()
-                            voteCounts.maxByOrNull { it.value }?.key ?: overlappingTimes.firstOrNull()?.first
-                        } else {
-                            // 최종 투표가 없으면 겹치는 시간 중 첫 번째
-                            overlappingTimes.firstOrNull()?.first
-                        }
+                        val totalMembers = memberUids.size
                         
-                        if (finalTime == null) {
-                            android.util.Log.e("FinalTimeVoteActivity", "최종 시간을 결정할 수 없습니다.")
-                            return@collectLatest
-                        }
+                        // 득표 수 계산
+                        val voteCounts = finalVotes.groupingBy { it }.eachCount()
+                        android.util.Log.d("FinalTimeVoteActivity", "📊 최종 투표 득표 현황: $voteCounts, 전체 멤버 수: $totalMembers")
                         
-                        // 최종 시간 확정
-                        val success = groupRepository.setFinalTime(groupId, date, finalTime)
+                        // 만장일치로 선택된 시간 찾기 (득표 수가 전체 멤버 수와 같은 시간)
+                        val unanimouslyVotedTime = voteCounts.entries.find { it.value == totalMembers }?.key
                         
-                        if (success) {
-                            // 그룹 상태를 LOCATION_INPUT_REQUIRED로 변경
-                            groupRepository.updateGroupStatus(groupId, "LOCATION_INPUT_REQUIRED")
+                        if (unanimouslyVotedTime != null) {
+                            // [시나리오 1: 만장일치 성공]
+                            android.util.Log.d("FinalTimeVoteActivity", "✅ 만장일치 성공! 최종 시간 확정: $unanimouslyVotedTime")
                             
-                            // 승리한 시간 다이얼로그 표시
-                            showWinningTimeDialog(finalTime)
+                            // 최종 시간 확정
+                            val success = groupRepository.setFinalTime(groupId, date, unanimouslyVotedTime)
+                            
+                            if (success) {
+                                // 그룹 상태를 LOCATION_INPUT_REQUIRED로 변경
+                                groupRepository.updateGroupStatus(groupId, "LOCATION_INPUT_REQUIRED")
+                                
+                                // 승리한 시간 다이얼로그 표시
+                                showWinningTimeDialog(unanimouslyVotedTime)
+                            } else {
+                                Toast.makeText(this@FinalTimeVoteActivity, "시간 확정에 실패했습니다.", Toast.LENGTH_SHORT).show()
+                            }
                         } else {
-                            Toast.makeText(this@FinalTimeVoteActivity, "시간 확정에 실패했습니다.", Toast.LENGTH_SHORT).show()
+                            // [시나리오 2: 만장일치 실패]
+                            android.util.Log.d("FinalTimeVoteActivity", "❌ 만장일치 실패! 득표 현황: $voteCounts")
+                            
+                            // 사용자에게 알리고 투표를 리셋
+                            showVoteFailedDialog()
                         }
                     }
                 }
@@ -239,6 +247,41 @@ class FinalTimeVoteActivity : AppCompatActivity() {
                 .create()
             
             winningTimeDialog?.show()
+        }
+    }
+
+    /**
+     * 만장일치 실패 시 사용자에게 알리는 다이얼로그
+     */
+    private fun showVoteFailedDialog() {
+        AlertDialog.Builder(this)
+            .setTitle("의견 불일치")
+            .setMessage("모든 멤버의 의견이 일치하지 않아 시간이 확정되지 못했습니다.\n다시 투표를 진행해주세요.")
+            .setPositiveButton("확인") { _, _ ->
+                // 최종 투표 데이터를 리셋하고 이전 화면으로 돌아가기
+                resetFinalVote()
+            }
+            .setCancelable(false)
+            .show()
+    }
+
+    /**
+     * 최종 투표를 리셋하는 함수
+     */
+    private fun resetFinalVote() {
+        lifecycleScope.launch {
+            try {
+                // Firestore의 최종 투표 기록 삭제
+                timeVoteRepository.clearFinalVotes(groupId, date)
+                
+                android.util.Log.d("FinalTimeVoteActivity", "✅ 최종 투표 리셋 완료")
+                
+                // Activity를 닫아 이전 화면으로 돌아가기
+                finish()
+            } catch (e: Exception) {
+                android.util.Log.e("FinalTimeVoteActivity", "❌ 최종 투표 리셋 실패: ${e.message}", e)
+                Toast.makeText(this@FinalTimeVoteActivity, "투표 리셋에 실패했습니다.", Toast.LENGTH_SHORT).show()
+            }
         }
     }
 

--- a/app/src/main/java/com/moyeoyo/app/ui/time/TimeVoteActivity.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/time/TimeVoteActivity.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
@@ -43,17 +44,14 @@ class TimeVoteActivity : AppCompatActivity() {
     @Inject
     lateinit var groupRepository: GroupRepository
     
+    private val viewModel: TimeVoteViewModel by viewModels()
+    
     private val auth = FirebaseAuth.getInstance()
 
     private lateinit var groupId: String
     private val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.KOREA)
     private var selectedDate: Date = Date()
     private val calendar = Calendar.getInstance()
-
-    // 날짜별로 선택된 시간 관리 (날짜 문자열 -> 시간 Set)
-    private val selectedTimesByDate = mutableMapOf<String, MutableSet<String>>()
-    private val selectedTimes: MutableSet<String>
-        get() = selectedTimesByDate.getOrPut(dateFormat.format(selectedDate)) { mutableSetOf() }
     
     private var selectedDayButton: View? = null
 
@@ -122,9 +120,12 @@ class TimeVoteActivity : AppCompatActivity() {
         if (isAlreadySelected) return  // 이미 선택된 버튼이면 무시
 
         val time = button.text.toString()
-        button.tag = true
-        selectedTimes.add(time)
+        val dateStr = dateFormat.format(selectedDate)
+        
+        // ViewModel의 장바구니에 추가
+        viewModel.toggleTimeSelection(dateStr, time)
 
+        button.tag = true
         button.backgroundTintList =
             ContextCompat.getColorStateList(this, R.color.brand_blue)
         button.setTextColor(ContextCompat.getColor(this, R.color.white))
@@ -145,21 +146,35 @@ class TimeVoteActivity : AppCompatActivity() {
 
         binding.btnPrevWeek.setOnClickListener {
             calendar.add(Calendar.WEEK_OF_YEAR, -1)
-            setupWeekDays()
-            updateWeekTitle()
-            // 주 변경 시 모든 날짜 관찰 다시 시작
-            observeFirestoreVotes()
+            // ⭐ 주 변경 시 장바구니는 유지되고, UI만 업데이트
+            updateWeekUI()
         }
 
         binding.btnNextWeek.setOnClickListener {
             calendar.add(Calendar.WEEK_OF_YEAR, 1)
-            setupWeekDays()
-            updateWeekTitle()
-            // 주 변경 시 모든 날짜 관찰 다시 시작
-            observeFirestoreVotes()
+            // ⭐ 주 변경 시 장바구니는 유지되고, UI만 업데이트
+            updateWeekUI()
         }
 
         setupWeekDays()
+    }
+    
+    /**
+     * 주 변경 시 UI만 업데이트 (장바구니는 유지)
+     */
+    private fun updateWeekUI() {
+        val tempCal = calendar.clone() as Calendar
+        tempCal.set(Calendar.DAY_OF_WEEK, Calendar.MONDAY)
+        
+        // 현재 선택된 날짜를 현재 주의 첫 번째 날짜(월요일)로 변경
+        selectedDate = tempCal.time
+        
+        setupWeekDays()
+        updateWeekTitle()
+        setupTimeGrid()
+        
+        // 주 변경 시 모든 날짜 관찰 다시 시작 (Firestore에서 현재 주 데이터 로드)
+        observeFirestoreVotes()
     }
 
     private fun updateWeekTitle() {
@@ -246,9 +261,9 @@ class TimeVoteActivity : AppCompatActivity() {
         grid.removeAllViews()
         timeButtons.clear()
         
-        // 현재 선택된 날짜의 선택된 시간 가져오기
+        // 현재 선택된 날짜의 선택된 시간 가져오기 (ViewModel의 장바구니에서)
         val dateStr = dateFormat.format(selectedDate)
-        val currentDateSelectedTimes = selectedTimesByDate.getOrPut(dateStr) { mutableSetOf() }
+        val currentDateSelectedTimes = viewModel.getSelectedTimesForDate(dateStr)
 
         val times = (0..23).map { String.format(Locale.KOREA, "%02d시", it) }
 
@@ -283,9 +298,11 @@ class TimeVoteActivity : AppCompatActivity() {
 
                 setOnClickListener {
                     val wasSelected = tag as Boolean
+                    // ViewModel의 장바구니에 추가/제거
+                    viewModel.toggleTimeSelection(dateStr, time)
+                    
                     tag = !wasSelected
                     if (!wasSelected) {
-                        selectedTimes.add(time)
                         backgroundTintList =
                             ContextCompat.getColorStateList(this@TimeVoteActivity, R.color.brand_blue)
                         setTextColor(
@@ -295,7 +312,6 @@ class TimeVoteActivity : AppCompatActivity() {
                             )
                         )
                     } else {
-                        selectedTimes.remove(time)
                         backgroundTintList =
                             ContextCompat.getColorStateList(this@TimeVoteActivity, R.color.white)
                         setTextColor(
@@ -350,6 +366,13 @@ class TimeVoteActivity : AppCompatActivity() {
             }
             .debounce(500) // 500ms debounce로 중복 호출 방지
             .collectLatest { allDatesData ->
+                // 모든 날짜의 Firestore 데이터를 selectedTimesByDate에 동기화
+                datesToObserve.forEachIndexed { index, dateStr ->
+                    if (index < allDatesData.size) {
+                        updateSelectedTimesFromFirestore(dateStr, allDatesData[index], uid)
+                    }
+                }
+                
                 // 현재 선택된 날짜의 데이터로 그리드 업데이트
                 val currentDateStr = dateFormat.format(selectedDate)
                 val currentDateIndex = datesToObserve.indexOf(currentDateStr)
@@ -370,35 +393,46 @@ class TimeVoteActivity : AppCompatActivity() {
     }
     
 
+    /**
+     * Firestore 데이터를 기반으로 ViewModel의 장바구니를 초기화 (모든 날짜에 대해)
+     */
+    private fun updateSelectedTimesFromFirestore(dateStr: String, data: Map<String, List<String>>, uid: String) {
+        // ViewModel의 장바구니에 Firestore 데이터 반영
+        viewModel.initializeSelectionsFromFirestore(dateStr, data, uid)
+    }
+    
+    /**
+     * 현재 선택된 날짜의 그리드를 Firestore 데이터로 업데이트
+     */
     private fun updateGridFromFirestore(data: Map<String, List<String>>, uid: String) {
         val grid = binding.gridTimeSlots
         val dateStr = dateFormat.format(selectedDate)
-        val currentDateSelectedTimes = selectedTimesByDate.getOrPut(dateStr) { mutableSetOf() }
+        
+        // ViewModel의 장바구니에 Firestore 데이터 반영
+        viewModel.initializeSelectionsFromFirestore(dateStr, data, uid)
+
+        // UI 업데이트: ViewModel의 장바구니 상태를 반영
+        val currentDateSelectedTimes = viewModel.getSelectedTimesForDate(dateStr)
 
         for (i in 0 until grid.childCount) {
             val button = grid.getChildAt(i) as MaterialButton
             val timeKey = button.text.toString().replace("시", ":00")
             val voters = data[timeKey] ?: emptyList()
             val isMyVote = voters.contains(uid)
+            val timeText = button.text.toString()
+            val isSelected = currentDateSelectedTimes.contains(timeText)
 
-            if (isMyVote) {
+            // 장바구니에 있는 시간은 선택된 것으로 표시
+            if (isSelected) {
                 button.tag = true
                 button.backgroundTintList =
                     ContextCompat.getColorStateList(this, R.color.brand_blue)
                 button.setTextColor(ContextCompat.getColor(this, R.color.white))
-                // ⚠️ selectedTimes에도 추가해야 함 (중복 방지)
-                val timeText = button.text.toString()
-                if (!currentDateSelectedTimes.contains(timeText)) {
-                    currentDateSelectedTimes.add(timeText)
-                }
             } else {
                 button.tag = false
                 button.backgroundTintList =
                     ContextCompat.getColorStateList(this, R.color.white)
                 button.setTextColor(ContextCompat.getColor(this, R.color.black))
-                // ⚠️ selectedTimes에서도 제거해야 함
-                val timeText = button.text.toString()
-                currentDateSelectedTimes.remove(timeText)
             }
         }
 
@@ -408,9 +442,10 @@ class TimeVoteActivity : AppCompatActivity() {
     // ----------------------- 하단 버튼 -----------------------
 
     private fun updateButtonState() {
-        // 모든 날짜의 선택된 시간 개수 계산
-        val totalCount = selectedTimesByDate.values.sumOf { it.size }
-        val dateCount = selectedTimesByDate.count { it.value.isNotEmpty() }
+        // ViewModel의 장바구니에서 모든 날짜의 선택된 시간 개수 계산
+        val pendingSelections = viewModel.pendingSelections.value
+        val totalCount = pendingSelections.values.sumOf { it.size }
+        val dateCount = pendingSelections.count { it.value.isNotEmpty() }
         
         if (dateCount > 0) {
             binding.btnCompleteVote.text = "저장 (${dateCount}개 날짜, ${totalCount}개 시간)"
@@ -429,8 +464,9 @@ class TimeVoteActivity : AppCompatActivity() {
 
     private fun setupButton() {
         binding.btnCompleteVote.setOnClickListener {
-            // 모든 날짜의 선택된 시간 확인
-            val datesWithTimes = selectedTimesByDate.filter { it.value.isNotEmpty() }
+            // ViewModel의 장바구니에서 모든 날짜의 선택된 시간 확인
+            val pendingSelections = viewModel.pendingSelections.value
+            val datesWithTimes = pendingSelections.filter { it.value.isNotEmpty() }
             
             if (datesWithTimes.isEmpty()) {
                 Toast.makeText(this, "선택된 시간이 없습니다", Toast.LENGTH_SHORT).show()
@@ -459,7 +495,7 @@ class TimeVoteActivity : AppCompatActivity() {
                 .setTitle("시간 저장 확인")
                 .setMessage(message)
                 .setPositiveButton("저장") { _, _ ->
-                    saveAllSelectedTimes(datesWithTimes)
+                    saveAllSelectedTimes()
                 }
                 .setNegativeButton("취소", null)
                 .show()
@@ -467,9 +503,9 @@ class TimeVoteActivity : AppCompatActivity() {
     }
     
     /**
-     * 모든 날짜의 선택된 시간을 한 번에 저장
+     * ViewModel의 장바구니에 담긴 모든 시간을 Firestore에 저장
      */
-    private fun saveAllSelectedTimes(datesWithTimes: Map<String, MutableSet<String>>) {
+    private fun saveAllSelectedTimes() {
         val uid = auth.currentUser?.uid ?: return
 
         lifecycleScope.launch {
@@ -477,27 +513,20 @@ class TimeVoteActivity : AppCompatActivity() {
                 // 중복 클릭 방지
                 binding.btnCompleteVote.isEnabled = false
                 
-                android.util.Log.d("TimeVoteActivity", "📝 저장 시작: ${datesWithTimes.size}개 날짜의 시간 투표 저장")
+                val pendingSelections = viewModel.pendingSelections.value
+                val dateCount = pendingSelections.count { it.value.isNotEmpty() }
+                val totalCount = pendingSelections.values.sumOf { it.size }
                 
-                // ⚠️ 모든 날짜의 모든 시간 저장 작업을 병렬로 실행하고 완료될 때까지 대기
-                coroutineScope {
-                    val allTasks = mutableListOf<kotlinx.coroutines.Deferred<Unit>>()
-                    
-                    datesWithTimes.forEach { (dateStr, times) ->
-                        times.forEach { time ->
-                            val task = async(Dispatchers.IO) {
-                                val formattedTime = time.replace("시", ":00")
-                                timeVoteRepository.voteTime(groupId, dateStr, formattedTime, uid)
-                            }
-                            allTasks.add(task)
-                        }
-                    }
-                    
-                    allTasks.awaitAll() // 모든 저장 작업이 완료될 때까지 여기서 대기
+                android.util.Log.d("TimeVoteActivity", "📝 저장 시작: ${dateCount}개 날짜의 시간 투표 저장")
+                
+                // ViewModel의 saveAllPendingSelections 호출
+                val result = viewModel.saveAllPendingSelections(groupId, uid)
+                
+                if (result.isFailure) {
+                    throw result.exceptionOrNull() ?: Exception("저장 실패")
                 }
                 
-                val totalCount = datesWithTimes.values.sumOf { it.size }
-                android.util.Log.d("TimeVoteActivity", "✅ 모든 시간 저장 작업 완료 (${datesWithTimes.size}개 날짜, ${totalCount}개 시간). 이제 멤버 투표 완료 여부를 확인합니다.")
+                android.util.Log.d("TimeVoteActivity", "✅ 모든 시간 저장 작업 완료 (${dateCount}개 날짜, ${totalCount}개 시간). 이제 멤버 투표 완료 여부를 확인합니다.")
                 
                 // 그룹 상태 확인 및 업데이트
                 val group = groupRepository.getGroupDetail(groupId)
@@ -506,7 +535,7 @@ class TimeVoteActivity : AppCompatActivity() {
                     groupRepository.updateGroupStatus(groupId, "TIME_VOTE_REQUIRED")
                 }
 
-                Toast.makeText(this@TimeVoteActivity, "${datesWithTimes.size}개 날짜의 시간이 저장되었습니다 ✅", Toast.LENGTH_SHORT).show()
+                Toast.makeText(this@TimeVoteActivity, "${dateCount}개 날짜의 시간이 저장되었습니다 ✅", Toast.LENGTH_SHORT).show()
                 
                 // Firestore 동기화를 위해 잠시 대기 (1초)
                 delay(1000)
@@ -527,9 +556,9 @@ class TimeVoteActivity : AppCompatActivity() {
                         android.util.Log.d("TimeVoteActivity", "✅ 겹치는 시간이 하나만 있음 - 자동 확정: ${allVoted.second[0]}")
                         autoConfirmFinalTime(allVoted.first, allVoted.second[0])
                     } else {
-                        // 모든 멤버가 투표 완료하고 겹치는 시간이 여러 개 -> 최종 투표 확인 팝업 표시
-                        android.util.Log.d("TimeVoteActivity", "✅ 저장 직후 모든 멤버 투표 완료 확인! (겹치는 시간: ${allVoted.second.size}개)")
-                        showFinalVoteConfirmationDialog(allVoted.first, allVoted.second)
+                        // 모든 멤버가 투표 완료하고 겹치는 시간이 여러 개 -> 바로 최종 투표 화면으로 이동
+                        android.util.Log.d("TimeVoteActivity", "✅ 저장 직후 모든 멤버 투표 완료 확인! 바로 최종 투표로 이동 (겹치는 시간: ${allVoted.second.size}개)")
+                        navigateToFinalVote(allVoted.first)
                     }
                 } else {
                     // 아직 다른 멤버가 남았다면 대기 다이얼로그 표시
@@ -768,56 +797,30 @@ class TimeVoteActivity : AppCompatActivity() {
     }
     
     /**
-     * 최종 투표 확인 팝업 표시
+     * 최종 투표 화면으로 바로 이동 (팝업 없이)
      */
-    private fun showFinalVoteConfirmationDialog(dateWithAllVoted: String, overlappingTimes: List<String>) {
+    private fun navigateToFinalVote(dateWithAllVoted: String) {
         if (hasNavigatedToFinalVote) return
+        hasNavigatedToFinalVote = true
         
-        // 기존 다이얼로그가 있으면 닫기
-        finalVoteConfirmationDialog?.dismiss()
-        
-        val dateDisplayFormat = SimpleDateFormat("yyyy년 MM월 dd일 (E)", Locale.KOREA)
-        val date = dateFormat.parse(dateWithAllVoted)
-        val dateDisplay = date?.let { dateDisplayFormat.format(it) } ?: dateWithAllVoted
-        
-        val message = buildString {
-            append("모든 멤버의 시간 투표가 완료되었습니다.\n\n")
-            append("겹치는 시간:\n")
-            overlappingTimes.forEach { time ->
-                append("• $time\n")
-            }
-            append("\n최종 시간 투표로 넘어가시겠습니까?")
-        }
-        
-        finalVoteConfirmationDialog = androidx.appcompat.app.AlertDialog.Builder(this)
-            .setTitle("최종 시간 투표")
-            .setMessage(message)
-            .setPositiveButton("이동") { _, _ ->
-                hasNavigatedToFinalVote = true
+        lifecycleScope.launch {
+            try {
+                // 그룹 상태를 TIME_FINALIZING으로 변경
+                groupRepository.updateGroupStatus(groupId, "TIME_FINALIZING")
                 
-                lifecycleScope.launch {
-                    try {
-                        // 그룹 상태를 TIME_FINALIZING으로 변경
-                        groupRepository.updateGroupStatus(groupId, "TIME_FINALIZING")
-                        
-                        // 최종 시간 투표 화면으로 이동
-                        val intent = android.content.Intent(this@TimeVoteActivity, FinalTimeVoteActivity::class.java).apply {
-                            putExtra("groupId", groupId)
-                            putExtra("date", dateWithAllVoted)
-                        }
-                        startActivity(intent)
-                        finish()
-                    } catch (e: Exception) {
-                        android.util.Log.e("TimeVoteActivity", "최종 투표 화면 이동 중 오류: ${e.message}", e)
-                        Toast.makeText(this@TimeVoteActivity, "오류가 발생했습니다: ${e.message}", Toast.LENGTH_SHORT).show()
-                    }
+                // 최종 시간 투표 화면으로 이동
+                val intent = android.content.Intent(this@TimeVoteActivity, FinalTimeVoteActivity::class.java).apply {
+                    putExtra("groupId", groupId)
+                    putExtra("date", dateWithAllVoted)
                 }
+                startActivity(intent)
+                finish()
+            } catch (e: Exception) {
+                android.util.Log.e("TimeVoteActivity", "최종 투표 화면 이동 중 오류: ${e.message}", e)
+                Toast.makeText(this@TimeVoteActivity, "오류가 발생했습니다: ${e.message}", Toast.LENGTH_SHORT).show()
+                hasNavigatedToFinalVote = false // 오류 발생 시 플래그 리셋
             }
-            .setNegativeButton("취소", null)
-            .setOnDismissListener { finalVoteConfirmationDialog = null }
-            .create()
-        
-        finalVoteConfirmationDialog?.show()
+        }
     }
     
     /**
@@ -890,9 +893,9 @@ class TimeVoteActivity : AppCompatActivity() {
                         android.util.Log.d("TimeVoteActivity", "✅ 겹치는 시간이 하나만 있음 - 자동 확정: ${overlappingTimes[0]}")
                         autoConfirmFinalTime(dateWithAllVoted, overlappingTimes[0])
                     } else {
-                        // 겹치는 시간이 여러 개 있으면 최종 투표 확인 팝업 표시
-                        android.util.Log.d("TimeVoteActivity", "✅ 모든 멤버 투표 완료 확인! 최종 투표 확인 팝업 표시. (날짜: $dateWithAllVoted, 겹치는 시간: ${overlappingTimes.size}개)")
-                        showFinalVoteConfirmationDialog(dateWithAllVoted, overlappingTimes)
+                        // 겹치는 시간이 여러 개 있으면 바로 최종 투표 화면으로 이동
+                        android.util.Log.d("TimeVoteActivity", "✅ 모든 멤버 투표 완료 확인! 바로 최종 투표로 이동. (날짜: $dateWithAllVoted, 겹치는 시간: ${overlappingTimes.size}개)")
+                        navigateToFinalVote(dateWithAllVoted)
                     }
                 } else if (hasAllVotedButNoOverlap) {
                     // 모든 멤버가 투표했지만 겹치는 시간이 없음

--- a/app/src/main/java/com/moyeoyo/app/ui/time/TimeVoteViewModel.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/time/TimeVoteViewModel.kt
@@ -1,0 +1,139 @@
+package com.moyeoyo.app.ui.time
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.moyeoyo.app.data.repository.TimeVoteRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * 시간 투표 화면의 ViewModel
+ * 주가 바뀌어도 선택 상태를 유지하는 '장바구니' 역할
+ */
+@HiltViewModel
+class TimeVoteViewModel @Inject constructor(
+    private val timeVoteRepository: TimeVoteRepository
+) : ViewModel() {
+
+    companion object {
+        private const val TAG = "TimeVoteViewModel"
+    }
+
+    /**
+     * ⭐ [핵심] 전체 선택 상태를 저장할 '장바구니'
+     * Key: "yyyy-MM-dd", Value: Set<"HH시">
+     * 주가 바뀌어도 절대 초기화되지 않음
+     */
+    private val _pendingSelections = MutableStateFlow<MutableMap<String, MutableSet<String>>>(mutableMapOf())
+    val pendingSelections: StateFlow<Map<String, Set<String>>> = _pendingSelections.asStateFlow()
+
+    /**
+     * 사용자가 시간을 선택/해제할 때 호출되는 함수
+     */
+    fun toggleTimeSelection(date: String, time: String) {
+        val currentSelections = _pendingSelections.value.toMutableMap()
+        val timesForDate = currentSelections.getOrPut(date) { mutableSetOf() }.toMutableSet()
+
+        if (timesForDate.contains(time)) {
+            timesForDate.remove(time)
+            Log.d(TAG, "시간 선택 해제: $date $time")
+        } else {
+            timesForDate.add(time)
+            Log.d(TAG, "시간 선택: $date $time")
+        }
+
+        currentSelections[date] = timesForDate
+        _pendingSelections.value = currentSelections
+    }
+
+    /**
+     * 특정 날짜의 선택된 시간 목록 가져오기
+     */
+    fun getSelectedTimesForDate(date: String): Set<String> {
+        return _pendingSelections.value[date]?.toSet() ?: emptySet()
+    }
+
+    /**
+     * 특정 날짜와 시간이 선택되어 있는지 확인
+     */
+    fun isTimeSelected(date: String, time: String): Boolean {
+        return _pendingSelections.value[date]?.contains(time) == true
+    }
+
+    /**
+     * Firestore에서 로드한 데이터로 장바구니 초기화 (앱 시작 시 또는 주 변경 시)
+     * 기존에 저장된 투표 데이터를 장바구니에 반영
+     */
+    fun initializeSelectionsFromFirestore(date: String, firestoreData: Map<String, List<String>>, uid: String) {
+        val currentSelections = _pendingSelections.value.toMutableMap()
+        val timesForDate = currentSelections.getOrPut(date) { mutableSetOf() }.toMutableSet()
+
+        // Firestore에서 현재 사용자가 투표한 시간만 추출하여 장바구니에 반영
+        firestoreData.forEach { (timeKey, voters) ->
+            if (voters.contains(uid)) {
+                // "14:00" -> "14시" 형식으로 변환
+                val hour = timeKey.split(":")[0].toIntOrNull() ?: 0
+                val timeText = "${hour}시"
+                timesForDate.add(timeText)
+            }
+        }
+
+        currentSelections[date] = timesForDate
+        _pendingSelections.value = currentSelections
+        Log.d(TAG, "Firestore 데이터로 장바구니 초기화: $date - ${timesForDate.size}개 시간")
+    }
+
+    /**
+     * '저장' 버튼을 눌렀을 때, 장바구니에 담긴 모든 내용을 Firestore에 한번에 저장
+     */
+    suspend fun saveAllPendingSelections(groupId: String, uid: String): Result<Unit> {
+        return try {
+            val selectionsToSave = _pendingSelections.value
+
+            if (selectionsToSave.isEmpty()) {
+                Log.d(TAG, "저장할 선택 항목이 없음")
+                return Result.success(Unit)
+            }
+
+            Log.d(TAG, "장바구니 내용 저장 시작: ${selectionsToSave.size}개 날짜")
+
+            // 모든 날짜의 모든 시간을 병렬로 저장
+            selectionsToSave.forEach { (dateStr, times) ->
+                times.forEach { time ->
+                    val formattedTime = time.replace("시", ":00")
+                    timeVoteRepository.voteTime(groupId, dateStr, formattedTime, uid)
+                }
+            }
+
+            Log.d(TAG, "✅ 장바구니 내용 저장 완료")
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Log.e(TAG, "전체 투표 저장 실패", e)
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * 장바구니 초기화 (필요한 경우)
+     */
+    fun clearPendingSelections() {
+        _pendingSelections.value = mutableMapOf()
+        Log.d(TAG, "장바구니 초기화")
+    }
+
+    /**
+     * 특정 날짜의 선택 상태 초기화
+     */
+    fun clearSelectionsForDate(date: String) {
+        val currentSelections = _pendingSelections.value.toMutableMap()
+        currentSelections.remove(date)
+        _pendingSelections.value = currentSelections
+        Log.d(TAG, "날짜별 선택 상태 초기화: $date")
+    }
+}
+


### PR DESCRIPTION
## 🕐 시간 투표 시스템 개선

### 주요 변경사항

#### 1. 시간 투표 주 변경 시 데이터 유지
- **문제**: 주 변경 시 투표칸이 비워지고 선택한 시간이 사라지는 문제
- **해결**: 주 변경 시에도 투표 데이터가 유지되도록 수정
- **결과**: 주를 변경해도 리셋되지 않고 모든 시간이 정상적으로 저장됨

#### 2. 최종 시간 투표 화면에 날짜 정보 표시
- **문제**: 최종 시간 투표 시 시간만 표시되어 어느 날짜의 시간인지 알 수 없음
- **해결**: `FinalTimeAdapter`에 날짜 정보를 포함하여 "yyyy년 MM월 dd일 (E) HH시" 형식으로 표시
- **결과**: 사용자가 선택한 시간이 어느 날짜의 시간인지 명확하게 확인 가능

#### 3. 최종 투표 만장일치 검사 로직 추가
- **문제**: 모든 멤버가 다른 시간에 투표해도 자동으로 확정되어 버리는 버그
- **해결**: 
  - 모든 멤버의 최종 투표 완료 시 만장일치 여부를 검사하는 로직 추가
  - 만장일치 성공 시에만 시간 확정
  - 만장일치 실패 시 "의견 불일치" 다이얼로그 표시 후 투표 리셋
- **결과**: 
  - 동점 발생 시 최종 투표만 다시 진행하도록 개선
  - 모든 멤버가 동일한 시간에 투표했을 때만 확정되어 공정성 보장

### 수정된 파일
- `FinalTimeAdapter.kt`: 날짜 정보 포함하도록 데이터 모델 변경
- `FinalTimeVoteActivity.kt`: 만장일치 검사 로직 및 실패 시 처리 추가
- `TimeVoteRepository.kt`: `clearFinalVotes()` 함수 추가 (투표 리셋용)
- `VoteTabHandler.kt`: `FinalTimeItem` 타입으로 변경하여 날짜 정보 전달

### 테스트 시나리오
1. ✅ 주 변경 시 투표 데이터 유지 확인
2. ✅ 최종 투표 화면에서 날짜와 시간 함께 표시 확인
3. ✅ 모든 멤버가 동일한 시간에 투표 시 정상 확정 확인
4. ✅ 멤버들이 다른 시간에 투표 시 재투표 요청 확인