### PR TITLE
feat: Add Room-based widget sync + realtime Firestore updates

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -120,4 +120,9 @@ dependencies {
 
     implementation("com.google.dagger:hilt-android:2.51.1")
     kapt("com.google.dagger:hilt-compiler:2.51.1")
+
+    implementation("androidx.room:room-runtime:2.6.1")
+    kapt("androidx.room:room-compiler:2.6.1")
+    implementation("androidx.room:room-ktx:2.6.1")
+
 }

--- a/app/src/main/java/com/moyeoyo/app/MainActivity.kt
+++ b/app/src/main/java/com/moyeoyo/app/MainActivity.kt
@@ -83,7 +83,10 @@ class MainActivity : AppCompatActivity() {
 
         // Firestore → Room 동기화
         val userId = auth.currentUser!!.uid
-        MeetingRepository(this).syncFromFirestore(userId)
+        val meetingRepo = MeetingRepository(this)
+
+        meetingRepo.syncFromFirestore(userId)       // 앱 켤 때 1회 실행
+        meetingRepo.observeGroupsRealtime(userId)   // 앱 살아 있는 동안 실시간 반영
 
         // FCM 토큰 저장
         saveFCMToken()

--- a/app/src/main/java/com/moyeoyo/app/MainActivity.kt
+++ b/app/src/main/java/com/moyeoyo/app/MainActivity.kt
@@ -23,6 +23,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import com.moyeoyo.app.R
+import com.moyeoyo.app.data.repository.MeetingRepository
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -80,6 +81,10 @@ class MainActivity : AppCompatActivity() {
             return
         }
 
+        // Firestore → Room 동기화
+        val userId = auth.currentUser!!.uid
+        MeetingRepository(this).syncFromFirestore(userId)
+
         // FCM 토큰 저장
         saveFCMToken()
 
@@ -92,7 +97,7 @@ class MainActivity : AppCompatActivity() {
 
         // 딥링크 처리
         deeplinkHandler.handle(intent)
-        //DeepLinkHandler(this).handle(intent)
+        DeepLinkHandler(this).handle(intent)
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/app/src/main/java/com/moyeoyo/app/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/moyeoyo/app/data/local/AppDatabase.kt
@@ -1,0 +1,26 @@
+package com.moyeoyo.app.data.local
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+
+@Database(entities = [NextMeetingEntity::class], version = 1)
+abstract class AppDatabase : RoomDatabase() {
+
+    abstract fun nextMeetingDao(): NextMeetingDao
+
+    companion object {
+        @Volatile private var INSTANCE: AppDatabase? = null
+
+        fun getInstance(context: Context): AppDatabase {
+            return INSTANCE ?: synchronized(this) {
+                Room.databaseBuilder(
+                    context.applicationContext,
+                    AppDatabase::class.java,
+                    "moyeoyo.db"
+                ).build().also { INSTANCE = it }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/moyeoyo/app/data/local/NextMeetingDao.kt
+++ b/app/src/main/java/com/moyeoyo/app/data/local/NextMeetingDao.kt
@@ -18,4 +18,10 @@ interface NextMeetingDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsert(meeting: NextMeetingEntity)
+
+    @Query("DELETE FROM next_meeting WHERE groupId = :groupId")
+    suspend fun deleteByGroupId(groupId: String)
+
+    @Query("SELECT groupId FROM next_meeting")
+    suspend fun getAllGroupIds(): List<String>
 }

--- a/app/src/main/java/com/moyeoyo/app/data/local/NextMeetingDao.kt
+++ b/app/src/main/java/com/moyeoyo/app/data/local/NextMeetingDao.kt
@@ -1,0 +1,16 @@
+package com.moyeoyo.app.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface NextMeetingDao {
+
+    @Query("SELECT * FROM next_meeting ORDER BY finalMeetingAt LIMIT 1")
+    suspend fun getNextMeeting(): NextMeetingEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(meeting: NextMeetingEntity)
+}

--- a/app/src/main/java/com/moyeoyo/app/data/local/NextMeetingDao.kt
+++ b/app/src/main/java/com/moyeoyo/app/data/local/NextMeetingDao.kt
@@ -8,8 +8,13 @@ import androidx.room.Query
 @Dao
 interface NextMeetingDao {
 
-    @Query("SELECT * FROM next_meeting ORDER BY finalMeetingAt LIMIT 1")
-    suspend fun getNextMeeting(): NextMeetingEntity?
+    @Query("""
+        SELECT * FROM next_meeting
+        WHERE finalMeetingAt > :now
+        ORDER BY finalMeetingAt ASC
+        LIMIT 1
+    """)
+    suspend fun getNextUpcomingMeeting(now: Long): NextMeetingEntity?
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsert(meeting: NextMeetingEntity)

--- a/app/src/main/java/com/moyeoyo/app/data/local/NextMeetingEntity.kt
+++ b/app/src/main/java/com/moyeoyo/app/data/local/NextMeetingEntity.kt
@@ -1,0 +1,12 @@
+package com.moyeoyo.app.data.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "next_meeting")
+data class NextMeetingEntity(
+    @PrimaryKey val groupId: String,
+    val groupName: String,
+    val finalMeetingAt: Long,
+    val finalMeetingPlace: String
+)

--- a/app/src/main/java/com/moyeoyo/app/data/local/utils/LocalMeetingHelper.kt
+++ b/app/src/main/java/com/moyeoyo/app/data/local/utils/LocalMeetingHelper.kt
@@ -1,0 +1,41 @@
+package com.moyeoyo.app.data.local
+
+import android.content.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * ⭐ Firestore 일정 확정 시 Room에 저장
+ */
+suspend fun saveMeetingToLocal(
+    context: Context,
+    groupId: String,
+    groupName: String,
+    meetingAt: Long,
+    placeName: String
+) {
+    withContext(Dispatchers.IO) {
+        val dao = AppDatabase.getInstance(context).nextMeetingDao()
+        dao.upsert(
+            NextMeetingEntity(
+                groupId = groupId,
+                groupName = groupName,
+                finalMeetingAt = meetingAt,
+                finalMeetingPlace = placeName
+            )
+        )
+    }
+}
+
+/**
+ * ⭐ 그룹 삭제 시 Room 일정 삭제
+ */
+suspend fun deleteMeetingFromLocal(
+    context: Context,
+    groupId: String
+) {
+    withContext(Dispatchers.IO) {
+        val dao = AppDatabase.getInstance(context).nextMeetingDao()
+        dao.deleteByGroupId(groupId)
+    }
+}

--- a/app/src/main/java/com/moyeoyo/app/data/repository/GroupRepository.kt
+++ b/app/src/main/java/com/moyeoyo/app/data/repository/GroupRepository.kt
@@ -1,5 +1,6 @@
 package com.moyeoyo.app.data.repository
 
+import android.content.Context
 import android.util.Log
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.CollectionReference
@@ -8,6 +9,8 @@ import com.google.firebase.firestore.GeoPoint
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FieldPath
+import com.moyeoyo.app.data.local.AppDatabase
+import com.moyeoyo.app.data.local.NextMeetingEntity
 import com.moyeoyo.app.data.model.Group
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
@@ -305,6 +308,7 @@ class GroupRepository @Inject constructor(
      * ⭐ NEW: 확정된 일정 정보(장소/시간)를 Firestore에 저장하고 그룹 상태를 변경합니다.
      */
     suspend fun confirmGroupSchedule(
+        context: Context,
         groupId: String,
         confirmedPlace: Map<String, Any>,
         confirmedTime: Timestamp,
@@ -317,17 +321,28 @@ class GroupRepository @Inject constructor(
                 "confirmedPlace" to confirmedPlace,
                 "confirmedTime" to confirmedTime,
                 "status" to "FINALIZED",
-                "groupName" to newTitle // 사용자가 입력한 제목으로 그룹 이름 업데이트
+                "groupName" to newTitle
             )
 
             groupRef.update(updates).await()
-            Log.d(TAG, "✅ 그룹 일정 확정 및 상태 변경: groupId=$groupId, status=FINALIZED")
+
+            // ⭐ 추가 위치 여기!!
+            saveMeetingToLocal(
+                context,
+                groupId,
+                newTitle,
+                confirmedTime.toDate().time,
+                confirmedPlace["name"] as? String ?: ""
+            )
+
+            Log.d(TAG, "confirmGroupSchedule SUCCESS")
             true
         } catch (e: Exception) {
-            Log.e(TAG, "❌ 그룹 일정 확정 실패: ${e.message}", e)
+            Log.e(TAG, "confirmGroupSchedule FAILED: ${e.message}")
             false
         }
     }
+
 
     /**
      * ⭐ NEW: 특정 멤버를 그룹에서 강퇴시킵니다. (removeMember)
@@ -407,6 +422,7 @@ class GroupRepository @Inject constructor(
      * ⭐ NEW: 확정된 일정 수정
      */
     suspend fun updateConfirmedSchedule(
+        context: Context,
         groupId: String,
         confirmedTime: Timestamp,
         confirmedPlace: Map<String, Any>
@@ -420,6 +436,15 @@ class GroupRepository @Inject constructor(
                     )
                 ).await()
 
+            // ⭐ Firestore 성공 후 Room에도 저장 — 이 위치에!
+            saveMeetingToLocal(
+                context,
+                groupId,
+                groupId,
+                confirmedTime.toDate().time,
+                confirmedPlace["name"] as? String ?: ""
+            )
+
             Log.d(TAG, "updateConfirmedSchedule SUCCESS")
             true
         } catch (e: Exception) {
@@ -428,34 +453,34 @@ class GroupRepository @Inject constructor(
         }
     }
 
+
     /**
      * 그룹과 그 하위 컬렉션의 모든 데이터를 삭제합니다.
      */
-    suspend fun deleteGroup(groupId: String): Boolean {
+    suspend fun deleteGroup(context: Context, groupId: String): Boolean {
         val groupRef = groupsCollection.document(groupId)
 
         return try {
-            // 1. 그룹 멤버 UID 목록 조회
             val groupSnapshot = groupRef.get().await()
             @Suppress("UNCHECKED_CAST")
             val memberUids = groupSnapshot.get("memberUids") as List<String>? ?: emptyList()
 
-            // 2. 하위 컬렉션 삭제
             deleteCollection(groupRef.collection("inputLocations"))
             deleteCollection(groupRef.collection("placeCandidates"))
             deleteCollection(groupRef.collection("timeCandidates"))
             deleteCollection(groupRef.collection("vote"))
 
-            // 3. 그룹 문서 삭제
             groupRef.delete().await()
 
-            // 4. 모든 멤버의 users 문서에서 groupId를 groups 배열에서 제거 (일괄 쓰기 사용)
             val batch = db.batch()
             memberUids.forEach { uid ->
                 val userRef = usersCollection.document(uid)
                 batch.update(userRef, "groups", FieldValue.arrayRemove(groupId))
             }
             batch.commit().await()
+
+            // ⭐⭐ 여기 추가해야 Room DB에서도 삭제됨!!
+            deleteMeetingFromLocal(context, groupId)
 
             Log.d("GroupRepository", "Group deleted successfully: $groupId")
             true
@@ -464,6 +489,7 @@ class GroupRepository @Inject constructor(
             false
         }
     }
+
 
     /**
      * Firestore 컬렉션의 모든 문서를 삭제하는 유틸리티 함수입니다.
@@ -480,5 +506,28 @@ class GroupRepository @Inject constructor(
         }
         batch.commit().await()
     }
+
+    private suspend fun saveMeetingToLocal(
+        context: Context,
+        groupId: String,
+        groupName: String,
+        confirmedTime: Long,
+        confirmedPlace: String
+    ) {
+        val dao = AppDatabase.getInstance(context).nextMeetingDao()
+
+        val entity = NextMeetingEntity(
+            groupId = groupId,
+            groupName = groupName,
+            finalMeetingAt = confirmedTime,
+            finalMeetingPlace = confirmedPlace
+        )
+        dao.upsert(entity)
+    }
+    private suspend fun deleteMeetingFromLocal(context: Context, groupId: String) {
+        val dao = AppDatabase.getInstance(context).nextMeetingDao()
+        dao.deleteByGroupId(groupId)
+    }
+
 
 }

--- a/app/src/main/java/com/moyeoyo/app/data/repository/MeetingRepository.kt
+++ b/app/src/main/java/com/moyeoyo/app/data/repository/MeetingRepository.kt
@@ -1,0 +1,64 @@
+package com.moyeoyo.app.data.repository
+
+import android.content.Context
+import android.content.Intent
+import androidx.appcompat.app.AppCompatActivity
+import com.google.firebase.firestore.FirebaseFirestore
+import com.moyeoyo.app.data.local.AppDatabase
+import com.moyeoyo.app.data.local.NextMeetingEntity
+import com.moyeoyo.app.widget.NextMeetingWidgetProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class MeetingRepository(private val context: Context) {
+
+    private val firestore = FirebaseFirestore.getInstance()
+    private val db = AppDatabase.getInstance(context)
+
+    /** Firestore에서 모임 정보를 받아 Room DB에 저장 */
+    fun syncFromFirestore(userId: String) {
+        firestore.collection("groups")
+            .whereArrayContains("memberUids", userId)
+            .get()
+            .addOnSuccessListener { snapshot ->
+
+                val meetings = snapshot.documents.mapNotNull { doc ->
+
+                    // Firestore 필드명 → confirmedTime, confirmedPlace
+                    val confirmedTime = doc.get("confirmedTime")
+                    val confirmedPlace = doc.get("confirmedPlace") as? Map<*, *>
+
+                    if (confirmedTime == null || confirmedPlace == null) return@mapNotNull null
+
+                    val time = when (confirmedTime) {
+                        is com.google.firebase.Timestamp -> confirmedTime.toDate().time
+                        is Long -> confirmedTime   // 혹시 Long으로 저장된 경우 대비
+                        else -> return@mapNotNull null
+                    }
+
+                    val placeName = confirmedPlace["name"] as? String ?: "장소 미정"
+                    val groupName = doc.getString("groupName") ?: "모임"
+
+                    NextMeetingEntity(
+                        groupId = doc.id,
+                        groupName = groupName,
+                        finalMeetingAt = time,
+                        finalMeetingPlace = placeName
+                    )
+                }
+
+                CoroutineScope(Dispatchers.IO).launch {
+                    val dao = db.nextMeetingDao()
+
+                    meetings.forEach { dao.upsert(it) }
+
+                    // 위젯 새로고침
+                    val intent = Intent(context, NextMeetingWidgetProvider::class.java)
+                    intent.action = "android.appwidget.action.APPWIDGET_UPDATE"
+                    context.sendBroadcast(intent)
+                }
+            }
+    }
+
+}

--- a/app/src/main/java/com/moyeoyo/app/data/repository/MeetingRepository.kt
+++ b/app/src/main/java/com/moyeoyo/app/data/repository/MeetingRepository.kt
@@ -2,7 +2,8 @@ package com.moyeoyo.app.data.repository
 
 import android.content.Context
 import android.content.Intent
-import androidx.appcompat.app.AppCompatActivity
+import android.util.Log
+import com.google.firebase.Timestamp
 import com.google.firebase.firestore.FirebaseFirestore
 import com.moyeoyo.app.data.local.AppDatabase
 import com.moyeoyo.app.data.local.NextMeetingEntity
@@ -10,13 +11,14 @@ import com.moyeoyo.app.widget.NextMeetingWidgetProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
 
 class MeetingRepository(private val context: Context) {
 
     private val firestore = FirebaseFirestore.getInstance()
     private val db = AppDatabase.getInstance(context)
 
-    /** Firestore에서 모임 정보를 받아 Room DB에 저장 */
+    // 수동 동기화 (앱 실행 시 1회 적용)
     fun syncFromFirestore(userId: String) {
         firestore.collection("groups")
             .whereArrayContains("memberUids", userId)
@@ -24,41 +26,83 @@ class MeetingRepository(private val context: Context) {
             .addOnSuccessListener { snapshot ->
 
                 val meetings = snapshot.documents.mapNotNull { doc ->
+                    mapToEntity(doc)
+                }
 
-                    // Firestore 필드명 → confirmedTime, confirmedPlace
-                    val confirmedTime = doc.get("confirmedTime")
-                    val confirmedPlace = doc.get("confirmedPlace") as? Map<*, *>
+                CoroutineScope(Dispatchers.IO).launch {
+                    val dao = db.nextMeetingDao()
+                    meetings.forEach { dao.upsert(it) }
 
-                    if (confirmedTime == null || confirmedPlace == null) return@mapNotNull null
+                    // 위젯 업데이트
+                    sendWidgetRefresh()
+                }
+            }
+    }
 
-                    val time = when (confirmedTime) {
-                        is com.google.firebase.Timestamp -> confirmedTime.toDate().time
-                        is Long -> confirmedTime   // 혹시 Long으로 저장된 경우 대비
-                        else -> return@mapNotNull null
-                    }
+    // 🔥 실시간 동기화 (앱이 열려 있는 동안 계속 동작)
+    fun observeGroupsRealtime(userId: String) {
+        firestore.collection("groups")
+            .whereArrayContains("memberUids", userId)
+            .addSnapshotListener { snapshot, error ->
 
-                    val placeName = confirmedPlace["name"] as? String ?: "장소 미정"
-                    val groupName = doc.getString("groupName") ?: "모임"
+                if (error != null) {
+                    Log.e("MeetingRepository", "Snapshot error: ${error.message}")
+                    return@addSnapshotListener
+                }
 
-                    NextMeetingEntity(
-                        groupId = doc.id,
-                        groupName = groupName,
-                        finalMeetingAt = time,
-                        finalMeetingPlace = placeName
-                    )
+                if (snapshot == null) return@addSnapshotListener
+
+                val meetings = snapshot.documents.mapNotNull { doc ->
+                    mapToEntity(doc)
                 }
 
                 CoroutineScope(Dispatchers.IO).launch {
                     val dao = db.nextMeetingDao()
 
+                    val existingIds = dao.getAllGroupIds()
+
+                    val newIds = meetings.map { it.groupId }
+
+                    val removedIds = existingIds.filter { it !in newIds }
+
+                    removedIds.forEach { dao.deleteByGroupId(it) }
+
                     meetings.forEach { dao.upsert(it) }
 
                     // 위젯 새로고침
-                    val intent = Intent(context, NextMeetingWidgetProvider::class.java)
-                    intent.action = "android.appwidget.action.APPWIDGET_UPDATE"
-                    context.sendBroadcast(intent)
+                    sendWidgetRefresh()
                 }
             }
     }
 
+    // 공통 엔티티 변환 함수
+    private fun mapToEntity(doc: com.google.firebase.firestore.DocumentSnapshot): NextMeetingEntity? {
+
+        val confirmedPlace = doc.get("confirmedPlace") as? Map<*, *> ?: return null
+        val confirmedTime = doc.get("confirmedTime") ?: return null
+
+        val finalAt = when (confirmedTime) {
+            is Timestamp -> confirmedTime.toDate().time
+            is Long -> confirmedTime
+            else -> return null
+        }
+
+        val groupName = doc.getString("groupName") ?: "모임"
+        val placeName = confirmedPlace["name"] as? String ?: "장소 미정"
+
+        return NextMeetingEntity(
+            groupId = doc.id,
+            groupName = groupName,
+            finalMeetingAt = finalAt,
+            finalMeetingPlace = placeName
+        )
+    }
+
+    // 위젯 업데이트 브로드캐스트
+    private fun sendWidgetRefresh() {
+        val intent = Intent(context, NextMeetingWidgetProvider::class.java).apply {
+            action = "android.appwidget.action.APPWIDGET_UPDATE"
+        }
+        context.sendBroadcast(intent)
+    }
 }

--- a/app/src/main/java/com/moyeoyo/app/ui/groups/GroupDetailActivity.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/groups/GroupDetailActivity.kt
@@ -845,17 +845,29 @@ class GroupDetailActivity : AppCompatActivity(), OnMapReadyCallback {
 
     private fun deleteGroup() {
         lifecycleScope.launch {
-            val success = groupRepository.deleteGroup(groupId)
+            val success = groupRepository.deleteGroup(
+                context = this@GroupDetailActivity,
+                groupId = groupId
+            )
 
             if (success) {
-                Toast.makeText(this@GroupDetailActivity, "'$groupName' 그룹을 삭제했습니다.", Toast.LENGTH_LONG).show()
+                Toast.makeText(
+                    this@GroupDetailActivity,
+                    "'$groupName' 그룹을 삭제했습니다.",
+                    Toast.LENGTH_LONG
+                ).show()
                 startActivity(Intent(this@GroupDetailActivity, MainActivity::class.java))
                 finish()
             } else {
-                Toast.makeText(this@GroupDetailActivity, "그룹 삭제에 실패했습니다.", Toast.LENGTH_LONG).show()
+                Toast.makeText(
+                    this@GroupDetailActivity,
+                    "그룹 삭제에 실패했습니다.",
+                    Toast.LENGTH_LONG
+                ).show()
             }
         }
     }
+
 
     private fun leaveGroup() {
         lifecycleScope.launch {

--- a/app/src/main/java/com/moyeoyo/app/ui/groups/GroupManageActivity.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/groups/GroupManageActivity.kt
@@ -6,8 +6,6 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle
 import android.widget.Toast
-import androidx.activity.result.ActivityResultLauncher
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
@@ -19,9 +17,11 @@ import com.google.android.libraries.places.widget.Autocomplete
 import com.google.android.libraries.places.widget.model.AutocompleteActivityMode
 import com.google.firebase.Timestamp
 import com.moyeoyo.app.MainActivity
+import com.moyeoyo.app.data.local.deleteMeetingFromLocal
 import com.moyeoyo.app.data.model.Group
 import com.moyeoyo.app.data.repository.GroupRepository
 import com.moyeoyo.app.databinding.ActivityGroupManageBinding
+import com.moyeoyo.app.widget.NextMeetingWidgetProvider
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import java.util.Calendar
@@ -42,7 +42,9 @@ class GroupManageActivity : AppCompatActivity() {
 
     // ⭐ 주소 검색 런처
     private val placeSearchLauncher =
-        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+        registerForActivityResult(
+            androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult()
+        ) { result ->
             handlePlaceResult(result)
         }
 
@@ -57,7 +59,7 @@ class GroupManageActivity : AppCompatActivity() {
             return
         }
 
-        // ⭐ Google Places 초기화 (ProfileSetup 방식 그대로)
+        // ⭐ Google Places 초기화
         if (!Places.isInitialized()) {
             val appInfo = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
             val apiKey = appInfo.metaData.getString("com.google.android.geo.API_KEY")
@@ -93,6 +95,9 @@ class GroupManageActivity : AppCompatActivity() {
         binding.scheduleSection.btnSaveSchedule.setOnClickListener { saveSchedule() }
     }
 
+    // ----------------------------------------------------
+    // 그룹 정보 불러오기
+    // ----------------------------------------------------
     private fun loadGroupInfo() {
         lifecycleScope.launch {
             val group = groupRepository.getGroupById(groupId)
@@ -138,7 +143,7 @@ class GroupManageActivity : AppCompatActivity() {
     }
 
     // ----------------------------------------------------
-    // ⭐ 주소 검색 로직: ProfileSetupActivity와 100% 동일
+    // ⭐ 주소 검색 로직
     // ----------------------------------------------------
     private fun startPlaceAutocomplete() {
         try {
@@ -181,12 +186,12 @@ class GroupManageActivity : AppCompatActivity() {
                 "longitude" to (latLng?.longitude ?: 0.0),
                 "placeId" to (place.id ?: "")
             )
-
         }
     }
 
-    // 날짜/시간 picker 그대로 유지 -----------------------------------------------
-
+    // ----------------------------------------------------
+    // 날짜/시간 picker
+    // ----------------------------------------------------
     private fun showDatePicker() {
         val cal = Calendar.getInstance()
         editedTimestamp?.let { cal.time = it.toDate() }
@@ -234,7 +239,7 @@ class GroupManageActivity : AppCompatActivity() {
     }
 
     // ----------------------------------------------------
-    // 일정 저장
+    // ⭐ 일정 저장 (수정)
     // ----------------------------------------------------
     private fun saveSchedule() {
         if (editedTimestamp == null) {
@@ -247,14 +252,21 @@ class GroupManageActivity : AppCompatActivity() {
         }
 
         lifecycleScope.launch {
+
+            // ⭐ 여기서 context 넣어서 호출해야함!
             val success = groupRepository.updateConfirmedSchedule(
-                groupId,
-                editedTimestamp!!,
-                editedPlaceMap!!
+                context = this@GroupManageActivity,
+                groupId = groupId,
+                confirmedTime = editedTimestamp!!,
+                confirmedPlace = editedPlaceMap!!
             )
 
             if (success) {
                 Toast.makeText(this@GroupManageActivity, "일정을 수정했습니다.", Toast.LENGTH_SHORT).show()
+
+                // ⭐ 위젯 갱신
+                NextMeetingWidgetProvider.requestUpdateAll(this@GroupManageActivity)
+
             } else {
                 Toast.makeText(this@GroupManageActivity, "일정 수정 실패", Toast.LENGTH_SHORT).show()
             }
@@ -273,9 +285,6 @@ class GroupManageActivity : AppCompatActivity() {
             .show()
     }
 
-    // ---------------------------
-    // 그룹 이름 저장
-    // ---------------------------
     private fun saveGroupName() {
         val newName = binding.editGroupName.text.toString().trim()
         if (newName.isEmpty()) {
@@ -288,20 +297,28 @@ class GroupManageActivity : AppCompatActivity() {
             if (success) {
                 Toast.makeText(this@GroupManageActivity, "그룹 이름을 수정했습니다.", Toast.LENGTH_SHORT).show()
             } else {
-                Toast.makeText(this@GroupManageActivity, "그룹 이름 수정에 실패했습니다.", Toast.LENGTH_SHORT).show()
+                Toast.makeText(this@GroupManageActivity, "그룹 이름 수정 실패", Toast.LENGTH_SHORT).show()
             }
         }
     }
 
-
     private fun deleteGroup() {
         lifecycleScope.launch {
-            val success = groupRepository.deleteGroup(groupId)
+            val success = groupRepository.deleteGroup(this@GroupManageActivity, groupId)
+
             if (success) {
+
+                // ⭐ Room 삭제 추가
+                deleteMeetingFromLocal(this@GroupManageActivity, groupId)
+
+                // ⭐ 위젯 갱신
+                NextMeetingWidgetProvider.requestUpdateAll(this@GroupManageActivity)
+
                 Toast.makeText(this@GroupManageActivity, "그룹이 삭제되었습니다.", Toast.LENGTH_LONG).show()
                 startActivity(Intent(this@GroupManageActivity, MainActivity::class.java))
                 finishAffinity()
             }
         }
     }
+
 }

--- a/app/src/main/java/com/moyeoyo/app/ui/place/FinalVoteActivity.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/place/FinalVoteActivity.kt
@@ -11,12 +11,14 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.firebase.auth.FirebaseAuth
 import com.moyeoyo.app.R
+import com.moyeoyo.app.data.local.saveMeetingToLocal
 import com.moyeoyo.app.data.model.NearbyPlace
 import com.moyeoyo.app.data.model.RankedPlace
 import com.moyeoyo.app.databinding.ActivityFinalVoteBinding
 import com.moyeoyo.app.data.repository.GroupRepository
 import com.moyeoyo.app.ui.place.FinalCandidate
 import com.moyeoyo.app.ui.place.RankedPlaceParcelable
+import com.moyeoyo.app.widget.NextMeetingWidgetProvider
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -240,13 +242,22 @@ class FinalVoteActivity : AppCompatActivity() {
                     "address" to (winningPlace.address ?: "")
                 )
                 groupRepository.confirmGroupSchedule(
+                    context = this@FinalVoteActivity,
                     groupId = groupId,
                     confirmedPlace = placeData,
-                    confirmedTime = group?.confirmedTime 
-                        ?: com.google.firebase.Timestamp.now(),
+                    confirmedTime = group?.confirmedTime ?: com.google.firebase.Timestamp.now(),
                     newTitle = groupName
                 )
-                
+                saveMeetingToLocal(
+                    context = this@FinalVoteActivity,
+                    groupId = groupId,
+                    groupName = groupName,
+                    meetingAt = (group?.confirmedTime ?: com.google.firebase.Timestamp.now()).toDate().time,
+                    placeName = winningPlace.name ?: ""
+                )
+
+// ⭐ 위젯 즉시 업데이트
+                NextMeetingWidgetProvider.requestUpdateAll(this@FinalVoteActivity)
                 // ⭐ 다이얼로그를 변수에 저장하여 onDestroy에서 닫을 수 있도록 함
                 winningPlaceDialog = AlertDialog.Builder(this@FinalVoteActivity)
                     .setTitle("최종 약속 장소 확정")

--- a/app/src/main/java/com/moyeoyo/app/ui/vote/ConfirmActivity.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/vote/ConfirmActivity.kt
@@ -29,6 +29,8 @@ import kotlinx.coroutines.launch
 import java.util.Calendar
 
 import com.google.firebase.Timestamp
+import com.moyeoyo.app.data.local.saveMeetingToLocal
+import com.moyeoyo.app.widget.NextMeetingWidgetProvider
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -208,6 +210,7 @@ class ConfirmActivity : AppCompatActivity() {
 
         lifecycleScope.launch {
             val success = groupRepository.confirmGroupSchedule(
+                context = this@ConfirmActivity,
                 groupId = groupId,
                 confirmedPlace = placeData,
                 confirmedTime = confirmedTimestamp,
@@ -215,14 +218,24 @@ class ConfirmActivity : AppCompatActivity() {
             )
 
             if (success) {
-                Toast.makeText(this@ConfirmActivity, "일정이 확정되고 DB에 저장되었습니다!", Toast.LENGTH_LONG).show()
-                binding.btnAddToGoogleCalendar.isEnabled = true
-                binding.btnAddToOtherApp.isEnabled = true
-            } else {
-                Toast.makeText(this@ConfirmActivity, "일정 확정 및 DB 저장 실패.", Toast.LENGTH_LONG).show()
+
+                // ⭐ Room 저장 추가
+                saveMeetingToLocal(
+                    context = this@ConfirmActivity,
+                    groupId = groupId,
+                    groupName = title,
+                    meetingAt = confirmedTimestamp.toDate().time,
+                    placeName = placeData["name"] as? String ?: ""
+                )
+
+                // ⭐ 위젯 갱신
+                NextMeetingWidgetProvider.requestUpdateAll(this@ConfirmActivity)
+
+                Toast.makeText(this@ConfirmActivity, "일정이 확정되었습니다!", Toast.LENGTH_LONG).show()
             }
         }
     }
+
 
     /**
      * ⭐ [FIX] Android Intent를 사용하여 캘린더 앱에 일정을 저장합니다.

--- a/app/src/main/java/com/moyeoyo/app/ui/widget/NextMeetingWidgetProvider.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/widget/NextMeetingWidgetProvider.kt
@@ -74,7 +74,8 @@ class NextMeetingWidgetProvider : AppWidgetProvider() {
             CoroutineScope(Dispatchers.IO).launch {
 
                 val dao = AppDatabase.getInstance(context).nextMeetingDao()
-                val meeting = dao.getNextMeeting()
+                val now = System.currentTimeMillis()
+                val meeting = dao.getNextUpcomingMeeting(now)
 
                 if (meeting == null) {
                     // 확정된 모임이 없을 때

--- a/app/src/main/java/com/moyeoyo/app/ui/widget/NextMeetingWidgetProvider.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/widget/NextMeetingWidgetProvider.kt
@@ -3,6 +3,7 @@ package com.moyeoyo.app.widget
 import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProvider
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.view.View
@@ -18,17 +19,16 @@ import java.util.*
 
 class NextMeetingWidgetProvider : AppWidgetProvider() {
 
-    override fun onUpdate(
-        context: Context,
-        appWidgetManager: AppWidgetManager,
-        appWidgetIds: IntArray
-    ) {
+    override fun onUpdate(context: Context, appWidgetManager: AppWidgetManager, appWidgetIds: IntArray) {
         super.onUpdate(context, appWidgetManager, appWidgetIds)
 
-        for (id in appWidgetIds) {
-            updateWidget(context, appWidgetManager, id)
+        CoroutineScope(Dispatchers.IO).launch {
+            appWidgetIds.forEach { id ->
+                updateWidget(context, appWidgetManager, id)
+            }
         }
     }
+
 
     companion object {
 
@@ -54,14 +54,17 @@ class NextMeetingWidgetProvider : AppWidgetProvider() {
             views.setViewVisibility(R.id.tvWidgetTime, View.GONE)
             views.setViewVisibility(R.id.tvWidgetPlace, View.GONE)
 
-            // 기본: 클릭하면 앱 홈으로 이동
+            // 🔥 PendingIntent 캐싱 문제 해결 → requestCode를 항상 다르게 생성
+            val uniqueRequestCode = (System.currentTimeMillis() % Int.MAX_VALUE).toInt()
+
+            // 기본 클릭 → 앱 실행
             val baseIntent = Intent(context, MainActivity::class.java).apply {
                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
             }
 
             val basePendingIntent = PendingIntent.getActivity(
                 context,
-                appWidgetId,
+                uniqueRequestCode, // ← 핵심!
                 baseIntent,
                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
             )
@@ -69,7 +72,7 @@ class NextMeetingWidgetProvider : AppWidgetProvider() {
             views.setOnClickPendingIntent(R.id.widget_root, basePendingIntent)
 
             // -------------------------------
-            // 🔥 여기부터 Room DB 읽기
+            // 🔥 Room DB 읽기 (가장 가까운 미래 모임)
             // -------------------------------
             CoroutineScope(Dispatchers.IO).launch {
 
@@ -78,14 +81,12 @@ class NextMeetingWidgetProvider : AppWidgetProvider() {
                 val meeting = dao.getNextUpcomingMeeting(now)
 
                 if (meeting == null) {
-                    // 확정된 모임이 없을 때
                     views.setTextViewText(R.id.tvWidgetDate, "다가오는 확정 모임이 없어요")
-
                     appWidgetManager.updateAppWidget(appWidgetId, views)
                     return@launch
                 }
 
-                // 확정된 모임 있을 때 UI 구성
+                // UI 표시
                 views.setViewVisibility(R.id.iconDate, View.VISIBLE)
                 views.setViewVisibility(R.id.iconTime, View.VISIBLE)
                 views.setViewVisibility(R.id.iconPlace, View.VISIBLE)
@@ -101,7 +102,7 @@ class NextMeetingWidgetProvider : AppWidgetProvider() {
                 views.setTextViewText(R.id.tvWidgetTime, timeFmt.format(date))
                 views.setTextViewText(R.id.tvWidgetPlace, meeting.finalMeetingPlace)
 
-                // 🔗 위젯 클릭 → 해당 그룹 상세로 이동
+                // 🔗 상세 이동 PendingIntent
                 val detailIntent = Intent(context, MainActivity::class.java).apply {
                     putExtra("from_widget", true)
                     putExtra("widget_group_id", meeting.groupId)
@@ -111,14 +112,26 @@ class NextMeetingWidgetProvider : AppWidgetProvider() {
 
                 val detailPendingIntent = PendingIntent.getActivity(
                     context,
-                    appWidgetId,
+                    uniqueRequestCode + 1, // ← requestCode 다르게!
                     detailIntent,
                     PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
                 )
 
                 views.setOnClickPendingIntent(R.id.widget_root, detailPendingIntent)
 
+                // 🔥 최종 UI 갱신
                 appWidgetManager.updateAppWidget(appWidgetId, views)
+            }
+        }
+
+        // 🔥 Firestore/Room 변화 시 강제 전체 위젯 업데이트 (MeetingRepository에서 호출)
+        fun requestUpdateAll(context: Context) {
+            val manager = AppWidgetManager.getInstance(context)
+            val ids = manager.getAppWidgetIds(
+                ComponentName(context, NextMeetingWidgetProvider::class.java)
+            )
+            ids.forEach { id ->
+                updateWidget(context, manager, id)
             }
         }
     }

--- a/app/src/main/java/com/moyeoyo/app/ui/widget/NextMeetingWidgetProvider.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/widget/NextMeetingWidgetProvider.kt
@@ -3,17 +3,16 @@ package com.moyeoyo.app.widget
 import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProvider
-import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
-import android.util.Log
 import android.view.View
 import android.widget.RemoteViews
-import com.google.firebase.Timestamp
-import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.firestore.FirebaseFirestore
 import com.moyeoyo.app.R
 import com.moyeoyo.app.MainActivity
+import com.moyeoyo.app.data.local.AppDatabase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -25,39 +24,38 @@ class NextMeetingWidgetProvider : AppWidgetProvider() {
         appWidgetIds: IntArray
     ) {
         super.onUpdate(context, appWidgetManager, appWidgetIds)
-        for (appWidgetId in appWidgetIds) {
-            updateWidget(context, appWidgetManager, appWidgetId)
+
+        for (id in appWidgetIds) {
+            updateWidget(context, appWidgetManager, id)
         }
     }
 
     companion object {
-
-        private const val TAG = "NextMeetingWidget"
 
         fun updateWidget(
             context: Context,
             appWidgetManager: AppWidgetManager,
             appWidgetId: Int
         ) {
+
             val views = RemoteViews(context.packageName, R.layout.widget_next_meeting)
 
-            // 기본 텍스트
+            // 기본 표시값
             views.setTextViewText(R.id.tvWidgetTitle, "다가오는 모임")
             views.setTextViewText(R.id.tvWidgetGroupName, "")
             views.setTextViewText(R.id.tvWidgetDate, "모임 정보를 불러오는 중…")
             views.setTextViewText(R.id.tvWidgetTime, "")
             views.setTextViewText(R.id.tvWidgetPlace, "")
 
-            // 기본적으로 아이콘/텍스트 숨김
+            // 숨겨야 할 뷰들
             views.setViewVisibility(R.id.iconDate, View.GONE)
             views.setViewVisibility(R.id.iconTime, View.GONE)
             views.setViewVisibility(R.id.iconPlace, View.GONE)
             views.setViewVisibility(R.id.tvWidgetTime, View.GONE)
             views.setViewVisibility(R.id.tvWidgetPlace, View.GONE)
 
-            // 항상 동작하는 "기본" PendingIntent (홈 열기용)
+            // 기본: 클릭하면 앱 홈으로 이동
             val baseIntent = Intent(context, MainActivity::class.java).apply {
-                // from_widget 안 넣음 → 그냥 앱 기본 시작 화면으로
                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
             }
 
@@ -68,124 +66,59 @@ class NextMeetingWidgetProvider : AppWidgetProvider() {
                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
             )
 
-            // 확정된 모임이 있든 없든, 일단 기본으로 홈으로 가는 클릭 리스너는 항상 설정
             views.setOnClickPendingIntent(R.id.widget_root, basePendingIntent)
 
-            val auth = FirebaseAuth.getInstance()
-            val user = auth.currentUser
+            // -------------------------------
+            // 🔥 여기부터 Room DB 읽기
+            // -------------------------------
+            CoroutineScope(Dispatchers.IO).launch {
 
-            if (user == null) {
-                views.setTextViewText(R.id.tvWidgetDate, "로그인 후 이용해주세요")
+                val dao = AppDatabase.getInstance(context).nextMeetingDao()
+                val meeting = dao.getNextMeeting()
+
+                if (meeting == null) {
+                    // 확정된 모임이 없을 때
+                    views.setTextViewText(R.id.tvWidgetDate, "다가오는 확정 모임이 없어요")
+
+                    appWidgetManager.updateAppWidget(appWidgetId, views)
+                    return@launch
+                }
+
+                // 확정된 모임 있을 때 UI 구성
+                views.setViewVisibility(R.id.iconDate, View.VISIBLE)
+                views.setViewVisibility(R.id.iconTime, View.VISIBLE)
+                views.setViewVisibility(R.id.iconPlace, View.VISIBLE)
+                views.setViewVisibility(R.id.tvWidgetTime, View.VISIBLE)
+                views.setViewVisibility(R.id.tvWidgetPlace, View.VISIBLE)
+
+                val dateFmt = SimpleDateFormat("yyyy년 M월 d일 (E)", Locale.KOREA)
+                val timeFmt = SimpleDateFormat("a h:mm", Locale.KOREA)
+                val date = Date(meeting.finalMeetingAt)
+
+                views.setTextViewText(R.id.tvWidgetGroupName, meeting.groupName)
+                views.setTextViewText(R.id.tvWidgetDate, dateFmt.format(date))
+                views.setTextViewText(R.id.tvWidgetTime, timeFmt.format(date))
+                views.setTextViewText(R.id.tvWidgetPlace, meeting.finalMeetingPlace)
+
+                // 🔗 위젯 클릭 → 해당 그룹 상세로 이동
+                val detailIntent = Intent(context, MainActivity::class.java).apply {
+                    putExtra("from_widget", true)
+                    putExtra("widget_group_id", meeting.groupId)
+                    putExtra("widget_group_name", meeting.groupName)
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                }
+
+                val detailPendingIntent = PendingIntent.getActivity(
+                    context,
+                    appWidgetId,
+                    detailIntent,
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                )
+
+                views.setOnClickPendingIntent(R.id.widget_root, detailPendingIntent)
+
                 appWidgetManager.updateAppWidget(appWidgetId, views)
-                return
-            }
-
-            val db = FirebaseFirestore.getInstance()
-
-            db.collection("groups")
-                .whereArrayContains("memberUids", user.uid)
-                .get()
-                .addOnSuccessListener { snapshot ->
-
-                    var upcomingMeeting: UpcomingMeeting? = null
-                    val now = System.currentTimeMillis()
-
-                    for (doc in snapshot.documents) {
-                        val groupName = doc.getString("groupName") ?: "모임"
-
-                        // Firestore 필드: confirmedPlace (Map), confirmedTime (Timestamp)
-                        val confirmedPlace = doc.get("confirmedPlace") as? Map<*, *>
-                        val confirmedTime = doc.get("confirmedTime") as? Timestamp
-
-                        // 🔹 둘 중 하나라도 없으면 확정된 모임 아님
-                        if (confirmedPlace == null || confirmedTime == null) continue
-
-                        val placeName = confirmedPlace["name"] as? String ?: "장소 미정"
-                        val finalAt = confirmedTime.toDate().time
-
-                        // 🔹 이미 지난 모임은 제외
-                        if (finalAt <= now) continue
-
-                        if (upcomingMeeting == null || finalAt < upcomingMeeting!!.finalAt) {
-                            upcomingMeeting = UpcomingMeeting(
-                                doc.id,
-                                groupName,
-                                finalAt,
-                                placeName
-                            )
-                        }
-                    }
-
-                    // 확정된 모임 없음 → 기본 PendingIntent(홈으로 이동)만 유지
-                    if (upcomingMeeting == null) {
-                        views.setTextViewText(R.id.tvWidgetDate, "다가오는 확정 모임이 없어요")
-                        // 아이콘, 시간/장소 텍스트는 숨긴 상태 그대로
-                        appWidgetManager.updateAppWidget(appWidgetId, views)
-                        return@addOnSuccessListener
-                    }
-
-                    // 확정된 모임 있음 → 아이콘/텍스트 보이기
-                    views.setViewVisibility(R.id.iconDate, View.VISIBLE)
-                    views.setViewVisibility(R.id.iconTime, View.VISIBLE)
-                    views.setViewVisibility(R.id.iconPlace, View.VISIBLE)
-                    views.setViewVisibility(R.id.tvWidgetTime, View.VISIBLE)
-                    views.setViewVisibility(R.id.tvWidgetPlace, View.VISIBLE)
-
-                    val meeting = upcomingMeeting!!
-
-                    val cal = Calendar.getInstance(TimeZone.getTimeZone("Asia/Seoul"), Locale.KOREA)
-                    cal.timeInMillis = meeting.finalAt
-
-                    val dateFmt = SimpleDateFormat("yyyy년 M월 d일 (E)", Locale.KOREA)
-                    val timeFmt = SimpleDateFormat("a h:mm", Locale.KOREA)
-
-                    views.setTextViewText(R.id.tvWidgetGroupName, meeting.groupName)
-                    views.setTextViewText(R.id.tvWidgetDate, dateFmt.format(cal.time))
-                    views.setTextViewText(R.id.tvWidgetTime, timeFmt.format(cal.time))
-                    views.setTextViewText(R.id.tvWidgetPlace, meeting.place)
-
-                    // 확정된 모임이 있을 때만 "그룹 디테일로 가는" 인텐트로 덮어쓰기
-                    val detailIntent = Intent(context, MainActivity::class.java).apply {
-                        putExtra("from_widget", true)
-                        putExtra("widget_group_id", meeting.groupId)
-                        putExtra("widget_group_name", meeting.groupName)
-                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
-                    }
-
-                    val detailPendingIntent = PendingIntent.getActivity(
-                        context,
-                        appWidgetId,
-                        detailIntent,
-                        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-                    )
-
-                    // 이 줄이 basePending 을 덮어씀 → 이 경우엔 디테일로 이동
-                    views.setOnClickPendingIntent(R.id.widget_root, detailPendingIntent)
-
-                    appWidgetManager.updateAppWidget(appWidgetId, views)
-                }
-                .addOnFailureListener { e ->
-                    Log.e(TAG, "Widget load error: ${e.message}")
-                    views.setTextViewText(R.id.tvWidgetDate, "데이터를 불러올 수 없어요")
-                    appWidgetManager.updateAppWidget(appWidgetId, views)
-                }
-        }
-
-        fun requestUpdateAll(context: Context) {
-            val manager = AppWidgetManager.getInstance(context)
-            val ids = manager.getAppWidgetIds(
-                ComponentName(context, NextMeetingWidgetProvider::class.java)
-            )
-            for (id in ids) {
-                updateWidget(context, manager, id)
             }
         }
     }
-
-    private data class UpcomingMeeting(
-        val groupId: String,
-        val groupName: String,
-        val finalAt: Long,
-        val place: String
-    )
 }


### PR DESCRIPTION
### 주요 변경사항
- 위젯 데이터 저장을 Firestore → Room DB 구조로 전환
- AppWidgetProvider 캐싱 문제 해결 (unique PendingIntent 적용)
- Firestore realtime snapshot listener 적용하여 자동 sync 구현
- 위젯 UI가 자동 업데이트되도록 requestUpdateAll() 호출 구조 개선

### 테스트 결과
- 확정 모임 생성/삭제/수정 시 위젯이 정상적으로 자동 업데이트됨
- 위젯 삭제 후 재생성 없이 최신 상태 반영 확인