### PR TITLE
알림 시스템 개선 및 위치 선택 기능 수정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,8 @@
     <uses-feature android:name="android.hardware.camera"
         android:required="true" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
 
     <application
         android:name=".App"
@@ -79,6 +81,10 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/next_meeting_widget_info" />
         </receiver>
+
+        <receiver
+            android:name=".services.ReminderNotificationReceiver"
+            android:exported="false" />
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/java/com/moyeoyo/app/MainActivity.kt
+++ b/app/src/main/java/com/moyeoyo/app/MainActivity.kt
@@ -102,6 +102,9 @@ class MainActivity : AppCompatActivity() {
         // 딥링크 처리
         deeplinkHandler.handle(intent)
         DeepLinkHandler(navController).handle(intent)
+        
+        // 푸시 알림 클릭 처리
+        handleNotificationIntent(intent)
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -109,6 +112,43 @@ class MainActivity : AppCompatActivity() {
         setIntent(intent)
         deeplinkHandler.handle(intent)
         DeepLinkHandler(navController).handle(intent)
+        
+        // 푸시 알림 클릭 처리
+        handleNotificationIntent(intent)
+    }
+    
+    /**
+     * 푸시 알림 클릭 시 그룹 상세 화면으로 이동
+     */
+    private fun handleNotificationIntent(intent: Intent) {
+        val notificationType = intent.getStringExtra("notification_type")
+        val groupId = intent.getStringExtra("groupId")
+        
+        if (notificationType == "group" && groupId != null) {
+            Log.d("MainActivity", "푸시 알림 클릭: 그룹 상세로 이동 - groupId: $groupId")
+            
+            lifecycleScope.launch {
+                try {
+                    // 그룹 정보 가져오기
+                    val group = groupRepository.getGroupById(groupId)
+                    val groupName = group?.groupName ?: "모임"
+                    
+                    // MainFragment로 먼저 이동 (백스택에 없을 수 있음)
+                    navController?.navigate(R.id.mainFragment)
+                    
+                    // GroupDetailFragment로 이동
+                    navController?.navigate(
+                        R.id.action_mainFragment_to_groupDetailFragment,
+                        Bundle().apply {
+                            putString("groupId", groupId)
+                            putString("groupName", groupName)
+                        }
+                    )
+                } catch (e: Exception) {
+                    Log.e("MainActivity", "그룹 상세 이동 실패: ${e.message}", e)
+                }
+            }
+        }
     }
 
     private fun saveFCMToken() {

--- a/app/src/main/java/com/moyeoyo/app/MainActivity.kt
+++ b/app/src/main/java/com/moyeoyo/app/MainActivity.kt
@@ -118,35 +118,53 @@ class MainActivity : AppCompatActivity() {
     }
     
     /**
-     * 푸시 알림 클릭 시 그룹 상세 화면으로 이동
+     * 푸시 알림 클릭 시 처리
      */
     private fun handleNotificationIntent(intent: Intent) {
-        val notificationType = intent.getStringExtra("notification_type")
+        val notificationType = intent.getStringExtra("notificationType") 
+            ?: intent.getStringExtra("notification_type")
         val groupId = intent.getStringExtra("groupId")
         
-        if (notificationType == "group" && groupId != null) {
-            Log.d("MainActivity", "푸시 알림 클릭: 그룹 상세로 이동 - groupId: $groupId")
-            
-            lifecycleScope.launch {
-                try {
-                    // 그룹 정보 가져오기
-                    val group = groupRepository.getGroupById(groupId)
-                    val groupName = group?.groupName ?: "모임"
+        lifecycleScope.launch {
+            try {
+                when {
+                    // 친구 요청 알림 → 인앱 알림창으로 이동
+                    notificationType == "friend_request" -> {
+                        Log.d("MainActivity", "Friend request notification clicked: navigating to notification fragment")
+                        
+                        // MainFragment로 먼저 이동
+                        navController?.navigate(R.id.mainFragment)
+                        
+                        // NotificationFragment로 이동
+                        navController?.navigate(R.id.notificationFragment)
+                    }
                     
-                    // MainFragment로 먼저 이동 (백스택에 없을 수 있음)
-                    navController?.navigate(R.id.mainFragment)
-                    
-                    // GroupDetailFragment로 이동
-                    navController?.navigate(
-                        R.id.action_mainFragment_to_groupDetailFragment,
-                        Bundle().apply {
-                            putString("groupId", groupId)
-                            putString("groupName", groupName)
-                        }
-                    )
-                } catch (e: Exception) {
-                    Log.e("MainActivity", "그룹 상세 이동 실패: ${e.message}", e)
+                    // 그룹 관련 알림 → 그룹 상세 화면으로 이동 + 자동 읽음 처리
+                    groupId != null && notificationType != null && notificationType in listOf("time_vote", "location_input", "final_vote", "finalized", "ranking", "reminder") -> {
+                        Log.d("MainActivity", "Group notification clicked: navigating to group detail - groupId: $groupId, type: $notificationType")
+                        
+                        // 알림 자동 읽음 처리
+                        notificationRepository.markNotificationAsReadByTypeAndGroup(notificationType, groupId)
+                        
+                        // 그룹 정보 가져오기
+                        val group = groupRepository.getGroupById(groupId)
+                        val groupName = group?.groupName ?: "모임"
+                        
+                        // MainFragment로 먼저 이동 (백스택에 없을 수 있음)
+                        navController?.navigate(R.id.mainFragment)
+                        
+                        // GroupDetailFragment로 이동
+                        navController?.navigate(
+                            R.id.action_mainFragment_to_groupDetailFragment,
+                            Bundle().apply {
+                                putString("groupId", groupId)
+                                putString("groupName", groupName)
+                            }
+                        )
+                    }
                 }
+            } catch (e: Exception) {
+                Log.e("MainActivity", "Failed to handle notification intent: ${e.message}", e)
             }
         }
     }

--- a/app/src/main/java/com/moyeoyo/app/data/local/NextMeetingDao.kt
+++ b/app/src/main/java/com/moyeoyo/app/data/local/NextMeetingDao.kt
@@ -24,4 +24,7 @@ interface NextMeetingDao {
 
     @Query("SELECT groupId FROM next_meeting")
     suspend fun getAllGroupIds(): List<String>
+    
+    @Query("SELECT * FROM next_meeting WHERE groupId = :groupId")
+    suspend fun getByGroupId(groupId: String): NextMeetingEntity?
 }

--- a/app/src/main/java/com/moyeoyo/app/data/repository/GroupRepository.kt
+++ b/app/src/main/java/com/moyeoyo/app/data/repository/GroupRepository.kt
@@ -389,6 +389,15 @@ class GroupRepository @Inject constructor(
                 confirmedPlace["name"] as? String ?: ""
             )
 
+            // ⭐ 로컬 알림 스케줄링 (약속 전날 같은 시간)
+            val scheduler = com.moyeoyo.app.services.LocalNotificationScheduler(context)
+            scheduler.scheduleNotificationForMeeting(
+                groupId,
+                newTitle,
+                confirmedTime.toDate().time,
+                confirmedPlace["name"] as? String ?: "장소 미정"
+            )
+
             Log.d(TAG, "confirmGroupSchedule SUCCESS")
             true
         } catch (e: Exception) {
@@ -482,6 +491,10 @@ class GroupRepository @Inject constructor(
         confirmedPlace: Map<String, Any>
     ): Boolean {
         return try {
+            // Firestore 업데이트
+            val groupDoc = groupsCollection.document(groupId).get().await()
+            val groupName = groupDoc.getString("groupName") ?: "모임"
+            
             groupsCollection.document(groupId)
                 .update(
                     mapOf(
@@ -490,16 +503,26 @@ class GroupRepository @Inject constructor(
                     )
                 ).await()
 
-            // ⭐ Firestore 성공 후 Room에도 저장 — 이 위치에!
+            // ⭐ Firestore 성공 후 Room에도 저장 (groupName 올바르게 전달)
             saveMeetingToLocal(
                 context,
                 groupId,
-                groupId,
+                groupName,  // ⚠️ 수정: groupId 대신 groupName 사용
                 confirmedTime.toDate().time,
                 confirmedPlace["name"] as? String ?: ""
             )
 
-            Log.d(TAG, "updateConfirmedSchedule SUCCESS")
+            // ⭐ 기존 알림 취소 후 새로 스케줄링
+            val scheduler = com.moyeoyo.app.services.LocalNotificationScheduler(context)
+            scheduler.cancelReminderNotification(groupId)  // 기존 알림 취소
+            scheduler.scheduleNotificationForMeeting(       // 새 알림 스케줄링
+                groupId,
+                groupName,
+                confirmedTime.toDate().time,
+                confirmedPlace["name"] as? String ?: "장소 미정"
+            )
+
+            Log.d(TAG, "updateConfirmedSchedule SUCCESS - RoomDB updated and notification rescheduled")
             true
         } catch (e: Exception) {
             Log.e(TAG, "updateConfirmedSchedule FAILED: ${e.message}")

--- a/app/src/main/java/com/moyeoyo/app/data/repository/NotificationRepository.kt
+++ b/app/src/main/java/com/moyeoyo/app/data/repository/NotificationRepository.kt
@@ -120,6 +120,78 @@ class NotificationRepository(
             Log.e(TAG, "markNotificationAsRead error: ${e.message}")
         }
     }
+    
+    /**
+     * type과 groupId로 최신 알림을 찾아서 읽음 처리
+     * 푸시 알림 클릭 시 자동 읽음 처리용
+     */
+    suspend fun markNotificationAsReadByTypeAndGroup(type: String, groupId: String? = null) {
+        val uid = auth.currentUser?.uid ?: return
+
+        try {
+            var query = db.collection("users")
+                .document(uid)
+                .collection("notifications")
+                .whereEqualTo("type", type)
+                .whereEqualTo("read", false)
+            
+            if (groupId != null) {
+                query = query.whereEqualTo("groupId", groupId)
+            }
+            
+            // orderBy 없이 모든 미읽음 알림을 가져와서 가장 최신 것 선택
+            val snapshot = query.get().await()
+            
+            // createdAt이 가장 최신인 알림 찾기 (클라이언트 측 정렬)
+            val latestDoc = snapshot.documents.maxByOrNull { doc ->
+                doc.getTimestamp("createdAt")?.seconds ?: 0L
+            }
+            
+            latestDoc?.let { doc ->
+                doc.reference.update("read", true).await()
+                Log.d(TAG, "Marked notification as read: type=$type, groupId=$groupId, id=${doc.id}")
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "markNotificationAsReadByTypeAndGroup error: ${e.message}")
+        }
+    }
+
+    /**
+     * 로컬 알림을 Firestore에 저장 (인앱 알림창 표시용)
+     */
+    suspend fun createLocalNotification(
+        title: String,
+        message: String,
+        type: String,
+        groupId: String? = null
+    ): Boolean {
+        val uid = auth.currentUser?.uid ?: return false
+
+        return try {
+            val notificationData = hashMapOf<String, Any>(
+                "title" to title,
+                "message" to message,
+                "type" to type,
+                "read" to false,
+                "handled" to false,
+                "createdAt" to com.google.firebase.firestore.FieldValue.serverTimestamp()
+            )
+            
+            groupId?.let { notificationData["groupId"] = it }
+            
+            db.collection("users")
+                .document(uid)
+                .collection("notifications")
+                .add(notificationData)
+                .await()
+            
+            Log.d(TAG, "Local notification created in Firestore")
+            true
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to create local notification: ${e.message}")
+            false
+        }
+    }
 
     /**
      * 알림 일괄 읽음 처리

--- a/app/src/main/java/com/moyeoyo/app/services/FirebaseMessagingService.kt
+++ b/app/src/main/java/com/moyeoyo/app/services/FirebaseMessagingService.kt
@@ -46,17 +46,15 @@ class FirebaseMessagingService : FirebaseMessagingService() {
     override fun onMessageReceived(remoteMessage: RemoteMessage) {
         Log.d(TAG, "From: ${remoteMessage.from}")
 
+        // 데이터 페이로드 가져오기
+        val data = remoteMessage.data
+
         // 💡 알림 페이로드가 있는 경우 (앱이 백그라운드일 때 기본 처리됨)
         remoteMessage.notification?.let {
             Log.d(TAG, "Message Notification Body: ${it.body}")
+            Log.d(TAG, "Message data payload: $data")
             // 포그라운드에서 수신 시 알림을 직접 띄웁니다.
-            sendNotification(it.title, it.body)
-        }
-
-        // 💡 데이터 페이로드가 있는 경우 (친구 요청 UID 등)
-        remoteMessage.data.isNotEmpty().let {
-            Log.d(TAG, "Message data payload: " + remoteMessage.data)
-            // 여기에서 알림 데이터를 처리하여 특정 화면으로 이동시킬 수 있습니다.
+            sendNotification(it.title, it.body, data)
         }
     }
 

--- a/app/src/main/java/com/moyeoyo/app/services/FirebaseMessagingService.kt
+++ b/app/src/main/java/com/moyeoyo/app/services/FirebaseMessagingService.kt
@@ -49,12 +49,25 @@ class FirebaseMessagingService : FirebaseMessagingService() {
         // 데이터 페이로드 가져오기
         val data = remoteMessage.data
 
+        // 리마인더 알림인 경우 로컬 알림 스케줄링 (notification이 있든 없든 처리)
+        val notificationType = data["type"]
+        val groupId = data["groupId"]
+        
+        if (notificationType == "reminder" && groupId != null) {
+            Log.d(TAG, "Reminder notification received (data only), scheduling local notification for group: $groupId")
+            val scheduler = LocalNotificationScheduler(this)
+            scheduler.scheduleReminderNotification(groupId)
+        }
+
         // 💡 알림 페이로드가 있는 경우 (앱이 백그라운드일 때 기본 처리됨)
         remoteMessage.notification?.let {
             Log.d(TAG, "Message Notification Body: ${it.body}")
             Log.d(TAG, "Message data payload: $data")
             // 포그라운드에서 수신 시 알림을 직접 띄웁니다.
-            sendNotification(it.title, it.body, data)
+            // 리마인더가 아닌 경우에만 즉시 알림 표시
+            if (notificationType != "reminder") {
+                sendNotification(it.title, it.body, data)
+            }
         }
     }
 
@@ -62,16 +75,28 @@ class FirebaseMessagingService : FirebaseMessagingService() {
      * 수신된 FCM 메시지를 Android Notification으로 표시합니다.
      */
     private fun sendNotification(title: String?, messageBody: String?, data: Map<String, String> = emptyMap()) {
+        // 리마인더 푸시 알림인 경우 로컬 알림으로 스케줄링
+        val notificationType = data["type"]
+        val groupId = data["groupId"]
+        
+        if (notificationType == "reminder" && groupId != null) {
+            Log.d(TAG, "Reminder notification received, scheduling local notification for group: $groupId")
+            val scheduler = LocalNotificationScheduler(this)
+            scheduler.scheduleReminderNotification(groupId)
+            // 리마인더는 즉시 표시하지 않고 로컬 알림으로만 처리
+            return
+        }
+        
         // 알림 클릭 시 메인 화면으로 이동하도록 Intent를 설정합니다.
         val intent = Intent(this, MainActivity::class.java).apply {
             addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
-            data["groupId"]?.let { groupId ->
-                putExtra("groupId", groupId)
-                Log.d(TAG, "Notification groupId: $groupId")
+            groupId?.let {
+                putExtra("groupId", it)
+                Log.d(TAG, "Notification groupId: $it")
             }
-            data["type"]?.let { type ->
-                putExtra("notificationType", type)
-                Log.d(TAG, "Notification type: $type")
+            notificationType?.let {
+                putExtra("notificationType", it)
+                Log.d(TAG, "Notification type: $it")
             }
         }
 

--- a/app/src/main/java/com/moyeoyo/app/services/FirebaseMessagingService.kt
+++ b/app/src/main/java/com/moyeoyo/app/services/FirebaseMessagingService.kt
@@ -61,10 +61,18 @@ class FirebaseMessagingService : FirebaseMessagingService() {
     /**
      * 수신된 FCM 메시지를 Android Notification으로 표시합니다.
      */
-    private fun sendNotification(title: String?, messageBody: String?) {
+    private fun sendNotification(title: String?, messageBody: String?, data: Map<String, String> = emptyMap()) {
         // 알림 클릭 시 메인 화면으로 이동하도록 Intent를 설정합니다.
         val intent = Intent(this, MainActivity::class.java).apply {
-            addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+            data["groupId"]?.let { groupId ->
+                putExtra("groupId", groupId)
+                Log.d(TAG, "Notification groupId: $groupId")
+            }
+            data["type"]?.let { type ->
+                putExtra("notificationType", type)
+                Log.d(TAG, "Notification type: $type")
+            }
         }
 
         // NotificationActivity로 이동하도록 수정할 수도 있습니다.

--- a/app/src/main/java/com/moyeoyo/app/services/LocalNotificationScheduler.kt
+++ b/app/src/main/java/com/moyeoyo/app/services/LocalNotificationScheduler.kt
@@ -1,0 +1,180 @@
+package com.moyeoyo.app.services
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import com.google.firebase.Timestamp
+import com.google.firebase.firestore.FirebaseFirestore
+import com.moyeoyo.app.data.local.AppDatabase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+class LocalNotificationScheduler(private val context: Context) {
+
+    private val TAG = "LocalNotificationScheduler"
+    private val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+    private val firestore = FirebaseFirestore.getInstance()
+
+    /**
+     * 리마인더 푸시 알림을 받았을 때, Firebase에서 약속 시간을 확인하고
+     * 약속 시간 1시간 전에 로컬 알림을 스케줄링합니다.
+     * Firebase 조회 실패 시 RoomDB를 fallback으로 사용합니다.
+     */
+    fun scheduleReminderNotification(groupId: String) {
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                // 1차: Firebase에서 직접 조회 (최신 데이터)
+                val meetingInfo = getMeetingInfoFromFirebase(groupId)
+                
+                if (meetingInfo != null) {
+                    Log.d(TAG, "Successfully retrieved meeting info from Firebase for group: $groupId")
+                    scheduleNotificationForMeeting(
+                        groupId,
+                        meetingInfo.first,  // groupName
+                        meetingInfo.second, // meetingTime
+                        meetingInfo.third   // placeName
+                    )
+                    return@launch
+                }
+                
+                // 2차: Firebase 조회 실패 시 RoomDB에서 조회 (오프라인 대응)
+                Log.d(TAG, "Firebase query failed, trying RoomDB fallback for group: $groupId")
+                val db = AppDatabase.getInstance(context)
+                val dao = db.nextMeetingDao()
+                
+                val meeting = dao.getByGroupId(groupId)
+                
+                if (meeting != null) {
+                    Log.d(TAG, "Successfully retrieved meeting info from RoomDB for group: $groupId")
+                    scheduleNotificationForMeeting(
+                        meeting.groupId,
+                        meeting.groupName,
+                        meeting.finalMeetingAt,
+                        meeting.finalMeetingPlace
+                    )
+                } else {
+                    Log.w(TAG, "Group $groupId not found in both Firebase and RoomDB")
+                }
+                
+            } catch (e: Exception) {
+                Log.e(TAG, "Error scheduling reminder notification: ${e.message}", e)
+            }
+        }
+    }
+    
+    /**
+     * Firebase에서 그룹 정보를 조회하여 약속 정보를 반환합니다.
+     * @return Triple(groupName, meetingTime, placeName) 또는 null
+     */
+    private suspend fun getMeetingInfoFromFirebase(groupId: String): Triple<String, Long, String>? {
+        return try {
+            val doc = firestore.collection("groups").document(groupId).get().await()
+            
+            if (!doc.exists()) {
+                Log.w(TAG, "Group document does not exist: $groupId")
+                return null
+            }
+            
+            val groupName = doc.getString("groupName") ?: "모임"
+            val confirmedTime = doc.get("confirmedTime") as? Timestamp
+            val confirmedPlace = doc.get("confirmedPlace") as? Map<*, *>
+            
+            if (confirmedTime == null) {
+                Log.w(TAG, "Confirmed time is null for group: $groupId")
+                return null
+            }
+            
+            val meetingTime = confirmedTime.toDate().time
+            val placeName = when {
+                confirmedPlace == null -> "장소 미정"
+                confirmedPlace["name"] is String -> confirmedPlace["name"] as String
+                else -> "장소 미정"
+            }
+            
+            Triple(groupName, meetingTime, placeName)
+            
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to get meeting info from Firebase: ${e.message}")
+            null
+        }
+    }
+    
+    /**
+     * 약속 정보를 직접 받아서 알림을 스케줄링합니다.
+     */
+    fun scheduleNotificationForMeeting(
+        groupId: String,
+        groupName: String,
+        meetingTime: Long,
+        placeName: String
+    ) {
+        val now = System.currentTimeMillis()
+        
+        // 약속 시간 전날 같은 시간으로 계산 (24시간 전)
+        val reminderTime = meetingTime - (24 * 60 * 60 * 1000) // 24시간 = 24 * 60분 * 60초 * 1000ms
+        
+        // 이미 지난 시간이면 스케줄링하지 않음
+        if (reminderTime <= now) {
+            Log.w(TAG, "Reminder time has already passed for group: $groupId")
+            return
+        }
+        
+        // Intent 생성
+        val intent = Intent(context, ReminderNotificationReceiver::class.java).apply {
+            putExtra("groupId", groupId)
+            putExtra("groupName", groupName)
+            putExtra("meetingTime", meetingTime)
+            putExtra("placeName", placeName)
+        }
+        
+        // PendingIntent 생성 (groupId를 requestCode로 사용하여 고유성 보장)
+        val pendingIntent = PendingIntent.getBroadcast(
+            context,
+            groupId.hashCode(),
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        
+        // AlarmManager로 알림 스케줄링
+        try {
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+                alarmManager.setExactAndAllowWhileIdle(
+                    AlarmManager.RTC_WAKEUP,
+                    reminderTime,
+                    pendingIntent
+                )
+            } else {
+                alarmManager.setExact(
+                    AlarmManager.RTC_WAKEUP,
+                    reminderTime,
+                    pendingIntent
+                )
+            }
+            Log.d(TAG, "Reminder notification scheduled for group: $groupName")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to schedule alarm: ${e.message}", e)
+        }
+    }
+    
+    /**
+     * 예약된 알림을 취소합니다.
+     */
+    fun cancelReminderNotification(groupId: String) {
+        val intent = Intent(context, ReminderNotificationReceiver::class.java)
+        val pendingIntent = PendingIntent.getBroadcast(
+            context,
+            groupId.hashCode(),
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        alarmManager.cancel(pendingIntent)
+        Log.d(TAG, "Cancelled reminder notification for group: $groupId")
+    }
+}
+

--- a/app/src/main/java/com/moyeoyo/app/services/ReminderNotificationReceiver.kt
+++ b/app/src/main/java/com/moyeoyo/app/services/ReminderNotificationReceiver.kt
@@ -1,0 +1,106 @@
+package com.moyeoyo.app.services
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import com.moyeoyo.app.MainActivity
+import com.moyeoyo.app.R
+import com.moyeoyo.app.data.repository.NotificationRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.*
+
+class ReminderNotificationReceiver : BroadcastReceiver() {
+
+    private val TAG = "ReminderNotificationReceiver"
+    private val CHANNEL_ID = "reminder_notification_channel"
+    private val CHANNEL_NAME = "약속 리마인더"
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val groupId = intent.getStringExtra("groupId") ?: run {
+            Log.e(TAG, "groupId is null")
+            return
+        }
+        val groupName = intent.getStringExtra("groupName") ?: "모임"
+        val meetingTime = intent.getLongExtra("meetingTime", 0L)
+        val placeName = intent.getStringExtra("placeName") ?: "장소 미정"
+        
+        if (meetingTime == 0L) {
+            Log.e(TAG, "Invalid meeting time")
+            return
+        }
+        
+        // 약속 시간 포맷팅
+        val timeFormat = SimpleDateFormat("HH:mm", Locale.getDefault())
+        val timeText = timeFormat.format(Date(meetingTime))
+        
+        // 알림 메시지 생성
+        val title = "🔔 내일 약속이 있어요!"
+        val message = "'$groupName' 약속이 내일 있어요!\n$placeName / $timeText"
+        
+        // 알림 채널 생성 (Android O 이상)
+        val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                CHANNEL_NAME,
+                NotificationManager.IMPORTANCE_HIGH
+            ).apply {
+                description = "약속 전날 알림"
+            }
+            notificationManager.createNotificationChannel(channel)
+        }
+        
+        // 알림 클릭 시 그룹 상세 화면으로 이동
+        val notificationIntent = Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            putExtra("groupId", groupId)
+            putExtra("notificationType", "reminder")
+        }
+        
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            groupId.hashCode(),
+            notificationIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        
+        // 알림 빌더
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_notification_bell)
+            .setContentTitle(title)
+            .setContentText(message)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(message))
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setDefaults(NotificationCompat.DEFAULT_ALL)
+            .setAutoCancel(true)
+            .setContentIntent(pendingIntent)
+            .build()
+        
+        // 알림 표시
+        notificationManager.notify(groupId.hashCode(), notification)
+        
+        // Firestore에 알림 문서 생성 (인앱 알림창 표시용)
+        val notificationRepository = NotificationRepository()
+        CoroutineScope(Dispatchers.IO).launch {
+            notificationRepository.createLocalNotification(
+                title = title,
+                message = message,
+                type = "reminder",
+                groupId = groupId
+            )
+        }
+        
+        Log.d(TAG, "Reminder notification displayed for group: $groupName")
+    }
+}
+

--- a/app/src/main/java/com/moyeoyo/app/ui/auth/ProfileSetupFragment.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/auth/ProfileSetupFragment.kt
@@ -374,18 +374,12 @@ class ProfileSetupFragment : Fragment() {
                 if (isHome) {
                     homeLocationData = finalLocationMap
                     Log.d("ProfileSetup", "handleConfirmedLocation: homeLocationData set = $homeLocationData")
-                    Snackbar.make(requireView(), "✅ 위치 설정 완료!\n주소: $addressText\nhomeLocationData: ${homeLocationData?.get("name")}", Snackbar.LENGTH_LONG).show()
                 } else {
                     workLocationData = finalLocationMap
                     Log.d("ProfileSetup", "handleConfirmedLocation: workLocationData set = $workLocationData")
-                    Snackbar.make(requireView(), "✅ 위치 설정 완료!\n주소: $addressText\nworkLocationData: ${workLocationData?.get("name")}", Snackbar.LENGTH_LONG).show()
                 }
                 
-                // 입력 필드에 값이 제대로 설정되었는지 확인
-                val actualText = if (isHome) inputHome.text.toString() else inputWork.text.toString()
-                if (actualText != addressText) {
-                    Snackbar.make(requireView(), "⚠️ 입력 필드 설정 실패!\n설정하려던 값: $addressText\n실제 값: $actualText", Snackbar.LENGTH_LONG).show()
-                }
+                Snackbar.make(requireView(), "위치가 지도에서 최종 설정되었습니다.", Snackbar.LENGTH_SHORT).show()
             } else {
                 Log.e("ProfileSetup", "handleConfirmedLocation: lat or lng is null")
                 Snackbar.make(requireView(), "위치 정보가 올바르지 않습니다.", Snackbar.LENGTH_SHORT).show()
@@ -441,9 +435,6 @@ class ProfileSetupFragment : Fragment() {
                                 "latLng" to LatLng(homeLat, homeLng),
                                 "placeId" to (homePlaceId ?: "")
                             )
-                            Snackbar.make(requireView(), "📥 기존 집 주소 로드됨: $homeAddress", Snackbar.LENGTH_SHORT).show()
-                        } else {
-                            Snackbar.make(requireView(), "ℹ️ 새로 설정한 위치가 있어 기존 주소를 덮어쓰지 않음\n현재: ${homeLocationData?.get("name")}", Snackbar.LENGTH_LONG).show()
                         }
                     }
                     if (!workAddress.isNullOrEmpty() && workLat != null && workLng != null) {
@@ -456,9 +447,6 @@ class ProfileSetupFragment : Fragment() {
                                 "latLng" to LatLng(workLat, workLng),
                                 "placeId" to (workPlaceId ?: "")
                             )
-                            Snackbar.make(requireView(), "📥 기존 회사 주소 로드됨: $workAddress", Snackbar.LENGTH_SHORT).show()
-                        } else {
-                            Snackbar.make(requireView(), "ℹ️ 새로 설정한 위치가 있어 기존 주소를 덮어쓰지 않음\n현재: ${workLocationData?.get("name")}", Snackbar.LENGTH_LONG).show()
                         }
                     }
 
@@ -578,22 +566,12 @@ class ProfileSetupFragment : Fragment() {
     private fun saveProfile() {
         val nickname = inputNickname.text.toString().trim()
 
-        Log.d("ProfileSetup", "saveProfile: nickname = $nickname")
-        Log.d("ProfileSetup", "saveProfile: homeLocationData = $homeLocationData")
-        Log.d("ProfileSetup", "saveProfile: workLocationData = $workLocationData")
-
-        // 디버깅 정보를 스낵바로 표시
-        val homeName = homeLocationData?.get("name") as? String ?: "null"
-        val homeAddr = homeLocationData?.get("address") as? String ?: "null"
-        val workName = workLocationData?.get("name") as? String ?: "null"
-        Snackbar.make(btnSave, "💾 저장 시도\n집: $homeName\n주소: $homeAddr\n회사: $workName", Snackbar.LENGTH_LONG).show()
-
         if (nickname.isEmpty()) {
             Snackbar.make(inputNickname, "닉네임을 입력해주세요", Snackbar.LENGTH_SHORT).show()
             return
         }
         if (homeLocationData == null) {
-            Snackbar.make(inputHome, "❌ 집 주소가 설정되지 않았습니다!\nhomeLocationData = null", Snackbar.LENGTH_LONG).show()
+            Snackbar.make(inputHome, "집 주소를 검색해주세요", Snackbar.LENGTH_SHORT).show()
             return
         }
 

--- a/app/src/main/java/com/moyeoyo/app/ui/auth/ProfileSetupFragment.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/auth/ProfileSetupFragment.kt
@@ -152,7 +152,8 @@ class ProfileSetupFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         // Fragment Result 리스너 설정
-        setFragmentResultListener(CurrentLocationFragment.RESULT_KEY) { _, bundle ->
+        requireActivity().supportFragmentManager.setFragmentResultListener(CurrentLocationFragment.RESULT_KEY, viewLifecycleOwner) { _, bundle ->
+            Log.d("ProfileSetup", "Fragment result received in listener: $bundle")
             handleConfirmedLocation(bundle)
         }
 
@@ -223,6 +224,17 @@ class ProfileSetupFragment : Fragment() {
         btnSave.setOnClickListener { saveProfile() }
 
         loadCurrentUserData()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        // Fragment가 다시 나타날 때 Fragment Result를 확인
+        // Navigation으로 돌아올 때 Fragment Result가 이미 설정되어 있을 수 있음
+        findNavController().previousBackStackEntry?.savedStateHandle?.get<Bundle>(CurrentLocationFragment.RESULT_KEY)?.let { bundle ->
+            Log.d("ProfileSetup", "Fragment result found in savedStateHandle: $bundle")
+            findNavController().previousBackStackEntry?.savedStateHandle?.remove<Bundle>(CurrentLocationFragment.RESULT_KEY)
+            handleConfirmedLocation(bundle)
+        }
     }
 
     override fun onDestroyView() {
@@ -320,36 +332,66 @@ class ProfileSetupFragment : Fragment() {
     }
 
     private fun handleConfirmedLocation(bundle: Bundle) {
+        Log.d("ProfileSetup", "handleConfirmedLocation called with bundle: $bundle")
+        
         @Suppress("UNCHECKED_CAST")
         val locationMap =
             bundle.getSerializable(CurrentLocationFragment.EXTRA_LOCATION_DATA) as? Map<String, Any>
         val isHome = bundle.getBoolean(CurrentLocationFragment.EXTRA_IS_HOME, true)
 
-        if (locationMap != null) {
-            val address = locationMap["address"] as? String ?: "주소 확인됨"
-            val targetInput = if (isHome) inputHome else inputWork
-            targetInput.setText(address)
+        Log.d("ProfileSetup", "handleConfirmedLocation: locationMap = $locationMap")
+        Log.d("ProfileSetup", "handleConfirmedLocation: isHome = $isHome")
 
-            // lat/lng를 LatLng 객체로 변환하여 저장
+        if (locationMap != null) {
+            // handlePlaceResult와 동일한 방식으로 처리
+            val name = locationMap["name"] as? String
+            val address = locationMap["address"] as? String ?: ""
+            
+            // name을 우선으로 사용, 없으면 address 사용 (handlePlaceResult와 동일)
+            val addressText = name ?: address ?: "선택된 장소"
+            val targetInput = if (isHome) inputHome else inputWork
+            targetInput.setText(addressText)
+            
+            Log.d("ProfileSetup", "handleConfirmedLocation: Setting input text to: $addressText")
+
+            // Fragment Result에서는 lat/lng가 분리되어 전달됨
             val lat = (locationMap["lat"] as? Number)?.toDouble()
             val lng = (locationMap["lng"] as? Number)?.toDouble()
             
             if (lat != null && lng != null) {
                 val latLng = LatLng(lat, lng)
-                val finalLocationMap = locationMap.toMutableMap().apply {
-                    put("latLng", latLng)
-                }
+                
+                // handlePlaceResult와 동일한 구조로 locationMap 생성
+                val finalLocationMap = hashMapOf<String, Any>(
+                    "name" to (name ?: (if (isHome) "집" else "직장")),
+                    "address" to address,
+                    "latLng" to latLng,
+                    "placeId" to (locationMap["placeId"] as? String ?: "")
+                )
+                
+                Log.d("ProfileSetup", "handleConfirmedLocation: finalLocationMap = $finalLocationMap")
                 
                 if (isHome) {
                     homeLocationData = finalLocationMap
+                    Log.d("ProfileSetup", "handleConfirmedLocation: homeLocationData set = $homeLocationData")
+                    Snackbar.make(requireView(), "✅ 위치 설정 완료!\n주소: $addressText\nhomeLocationData: ${homeLocationData?.get("name")}", Snackbar.LENGTH_LONG).show()
                 } else {
                     workLocationData = finalLocationMap
+                    Log.d("ProfileSetup", "handleConfirmedLocation: workLocationData set = $workLocationData")
+                    Snackbar.make(requireView(), "✅ 위치 설정 완료!\n주소: $addressText\nworkLocationData: ${workLocationData?.get("name")}", Snackbar.LENGTH_LONG).show()
                 }
-                Snackbar.make(requireView(), "위치가 지도에서 최종 설정되었습니다.", Snackbar.LENGTH_SHORT).show()
+                
+                // 입력 필드에 값이 제대로 설정되었는지 확인
+                val actualText = if (isHome) inputHome.text.toString() else inputWork.text.toString()
+                if (actualText != addressText) {
+                    Snackbar.make(requireView(), "⚠️ 입력 필드 설정 실패!\n설정하려던 값: $addressText\n실제 값: $actualText", Snackbar.LENGTH_LONG).show()
+                }
             } else {
+                Log.e("ProfileSetup", "handleConfirmedLocation: lat or lng is null")
                 Snackbar.make(requireView(), "위치 정보가 올바르지 않습니다.", Snackbar.LENGTH_SHORT).show()
             }
         } else {
+            Log.e("ProfileSetup", "handleConfirmedLocation: locationMap is null")
             Snackbar.make(requireView(), "위치 설정 결과 수신 실패.", Snackbar.LENGTH_SHORT).show()
         }
     }
@@ -390,22 +432,34 @@ class ProfileSetupFragment : Fragment() {
                         inputNickname.setText(nickname)
                     }
                     if (!homeAddress.isNullOrEmpty() && homeLat != null && homeLng != null) {
-                        inputHome.setText(homeAddress)
-                        homeLocationData = mapOf(
-                            "name" to (homeMap?.get("name") ?: "집"),
-                            "address" to homeAddress,
-                            "latLng" to LatLng(homeLat, homeLng),
-                            "placeId" to (homePlaceId ?: "")
-                        )
+                        // 이미 사용자가 새로운 위치를 설정했다면 덮어쓰지 않음
+                        if (homeLocationData == null) {
+                            inputHome.setText(homeAddress)
+                            homeLocationData = mapOf(
+                                "name" to (homeMap?.get("name") ?: "집"),
+                                "address" to homeAddress,
+                                "latLng" to LatLng(homeLat, homeLng),
+                                "placeId" to (homePlaceId ?: "")
+                            )
+                            Snackbar.make(requireView(), "📥 기존 집 주소 로드됨: $homeAddress", Snackbar.LENGTH_SHORT).show()
+                        } else {
+                            Snackbar.make(requireView(), "ℹ️ 새로 설정한 위치가 있어 기존 주소를 덮어쓰지 않음\n현재: ${homeLocationData?.get("name")}", Snackbar.LENGTH_LONG).show()
+                        }
                     }
                     if (!workAddress.isNullOrEmpty() && workLat != null && workLng != null) {
-                        inputWork.setText(workAddress)
-                        workLocationData = mapOf(
-                            "name" to (workMap?.get("name") ?: "직장"),
-                            "address" to workAddress,
-                            "latLng" to LatLng(workLat, workLng),
-                            "placeId" to (workPlaceId ?: "")
-                        )
+                        // 이미 사용자가 새로운 위치를 설정했다면 덮어쓰지 않음
+                        if (workLocationData == null) {
+                            inputWork.setText(workAddress)
+                            workLocationData = mapOf(
+                                "name" to (workMap?.get("name") ?: "직장"),
+                                "address" to workAddress,
+                                "latLng" to LatLng(workLat, workLng),
+                                "placeId" to (workPlaceId ?: "")
+                            )
+                            Snackbar.make(requireView(), "📥 기존 회사 주소 로드됨: $workAddress", Snackbar.LENGTH_SHORT).show()
+                        } else {
+                            Snackbar.make(requireView(), "ℹ️ 새로 설정한 위치가 있어 기존 주소를 덮어쓰지 않음\n현재: ${workLocationData?.get("name")}", Snackbar.LENGTH_LONG).show()
+                        }
                     }
 
                     if (!photoUrl.isNullOrEmpty()) {
@@ -524,12 +578,22 @@ class ProfileSetupFragment : Fragment() {
     private fun saveProfile() {
         val nickname = inputNickname.text.toString().trim()
 
+        Log.d("ProfileSetup", "saveProfile: nickname = $nickname")
+        Log.d("ProfileSetup", "saveProfile: homeLocationData = $homeLocationData")
+        Log.d("ProfileSetup", "saveProfile: workLocationData = $workLocationData")
+
+        // 디버깅 정보를 스낵바로 표시
+        val homeName = homeLocationData?.get("name") as? String ?: "null"
+        val homeAddr = homeLocationData?.get("address") as? String ?: "null"
+        val workName = workLocationData?.get("name") as? String ?: "null"
+        Snackbar.make(btnSave, "💾 저장 시도\n집: $homeName\n주소: $homeAddr\n회사: $workName", Snackbar.LENGTH_LONG).show()
+
         if (nickname.isEmpty()) {
             Snackbar.make(inputNickname, "닉네임을 입력해주세요", Snackbar.LENGTH_SHORT).show()
             return
         }
         if (homeLocationData == null) {
-            Snackbar.make(inputHome, "집 주소를 검색해주세요", Snackbar.LENGTH_SHORT).show()
+            Snackbar.make(inputHome, "❌ 집 주소가 설정되지 않았습니다!\nhomeLocationData = null", Snackbar.LENGTH_LONG).show()
             return
         }
 

--- a/app/src/main/java/com/moyeoyo/app/ui/location/CurrentLocationFragment.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/location/CurrentLocationFragment.kt
@@ -2,6 +2,7 @@ package com.moyeoyo.app.ui.location
 
 import android.content.pm.PackageManager
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -96,6 +97,9 @@ class CurrentLocationFragment : Fragment(), OnMapReadyCallback, GoogleMap.OnCame
         googleMap.setOnCameraIdleListener(this)
 
         googleMap.moveCamera(CameraUpdateFactory.newLatLngZoom(receivedLatLng, 17f))
+        // Activity 버전과 동일: onCameraIdle이 자동으로 호출되어 초기 위치 정보 로드
+        // 하지만 안전을 위해 초기 위치 정보도 즉시 로드
+        fetchLocationDetails(receivedLatLng)
     }
 
     override fun onCameraIdle() {
@@ -129,7 +133,8 @@ class CurrentLocationFragment : Fragment(), OnMapReadyCallback, GoogleMap.OnCame
         textLocationName.text = finalName
         textAddress.text = addressLine
 
-        // LatLng는 Serializable이 아니므로 lat/lng를 분리해서 저장
+        // Fragment Result의 Bundle은 Serializable만 지원하므로 lat/lng를 분리해서 저장
+        // (Activity 버전에서는 Intent에 Bundle을 넣을 수 있어 Parcelable도 가능했음)
         confirmedLocationMap = mapOf(
             "name" to finalName,
             "address" to addressLine,
@@ -268,20 +273,31 @@ class CurrentLocationFragment : Fragment(), OnMapReadyCallback, GoogleMap.OnCame
     }
 
     private fun returnConfirmedLocation() {
+        // Activity 버전과 동일: null 체크만 수행
         if (confirmedLocationMap == null) {
             finishWithToast("위치 정보가 유효하지 않습니다.")
             return
         }
 
-        // Fragment Result로 데이터 전달
-        // LatLng는 Parcelable이므로 Bundle에 직접 넣을 수 없으므로 Map으로 전달
+        Log.d("CurrentLocation", "returnConfirmedLocation: confirmedLocationMap = $confirmedLocationMap")
+        Log.d("CurrentLocation", "returnConfirmedLocation: isHomeLocation = $isHomeLocation")
+
+        // Activity 버전과 동일한 방식으로 Bundle 생성
         val result = Bundle().apply {
-            // LatLng를 포함한 Map을 Serializable로 전달
             putSerializable(EXTRA_LOCATION_DATA, confirmedLocationMap as Serializable)
             putBoolean(EXTRA_IS_HOME, isHomeLocation)
         }
-        parentFragmentManager.setFragmentResult(RESULT_KEY, result)
         
+        Log.d("CurrentLocation", "returnConfirmedLocation: Setting fragment result with key = $RESULT_KEY")
+        
+        // 여러 방법으로 Fragment Result 전달 시도
+        // 1. Activity의 supportFragmentManager 사용
+        requireActivity().supportFragmentManager.setFragmentResult(RESULT_KEY, result)
+        
+        // 2. Navigation의 savedStateHandle에도 저장 (onResume에서 확인 가능)
+        findNavController().previousBackStackEntry?.savedStateHandle?.set(RESULT_KEY, result)
+        
+        Log.d("CurrentLocation", "returnConfirmedLocation: Fragment result set via both methods, popping back")
         findNavController().popBackStack()
     }
 

--- a/app/src/main/java/com/moyeoyo/app/ui/location/CurrentLocationFragment.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/location/CurrentLocationFragment.kt
@@ -291,13 +291,20 @@ class CurrentLocationFragment : Fragment(), OnMapReadyCallback, GoogleMap.OnCame
         Log.d("CurrentLocation", "returnConfirmedLocation: Setting fragment result with key = $RESULT_KEY")
         
         // 여러 방법으로 Fragment Result 전달 시도
-        // 1. Activity의 supportFragmentManager 사용
+        // 1. Activity의 supportFragmentManager 사용 (가장 확실한 방법)
         requireActivity().supportFragmentManager.setFragmentResult(RESULT_KEY, result)
+        Log.d("CurrentLocation", "returnConfirmedLocation: Fragment result set via Activity supportFragmentManager")
         
         // 2. Navigation의 savedStateHandle에도 저장 (onResume에서 확인 가능)
+        // previousBackStackEntry에 저장 (LocationInputFragment가 이전 Fragment)
         findNavController().previousBackStackEntry?.savedStateHandle?.set(RESULT_KEY, result)
+        Log.d("CurrentLocation", "returnConfirmedLocation: Fragment result set in previousBackStackEntry savedStateHandle")
         
-        Log.d("CurrentLocation", "returnConfirmedLocation: Fragment result set via both methods, popping back")
+        // 3. currentBackStackEntry에도 저장 (혹시 모를 경우를 대비)
+        findNavController().currentBackStackEntry?.savedStateHandle?.set(RESULT_KEY, result)
+        Log.d("CurrentLocation", "returnConfirmedLocation: Fragment result set in currentBackStackEntry savedStateHandle")
+        
+        Log.d("CurrentLocation", "returnConfirmedLocation: Fragment result set via all methods, popping back")
         findNavController().popBackStack()
     }
 

--- a/app/src/main/java/com/moyeoyo/app/ui/location/LocationInputFragment.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/location/LocationInputFragment.kt
@@ -9,6 +9,8 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.EditText
+import android.widget.ImageView
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
@@ -102,9 +104,13 @@ class LocationInputFragment : Fragment() {
         rootView = view
 
         // Fragment Result 리스너 설정
-        setFragmentResultListener(CurrentLocationFragment.RESULT_KEY) { _, bundle ->
+        // Navigation을 사용할 때는 Activity의 supportFragmentManager를 사용해야 함
+        requireActivity().supportFragmentManager.setFragmentResultListener(CurrentLocationFragment.RESULT_KEY, viewLifecycleOwner) { requestKey, bundle ->
+            Log.d("LocationInput", "Fragment result received in listener: requestKey=$requestKey, bundle=$bundle")
             handleConfirmedLocation(bundle)
         }
+        
+        Log.d("LocationInput", "Fragment Result listener registered with key: ${CurrentLocationFragment.RESULT_KEY}")
 
         fusedLocationClient = LocationServices.getFusedLocationProviderClient(requireContext())
         firestore = FirebaseFirestore.getInstance()
@@ -116,6 +122,30 @@ class LocationInputFragment : Fragment() {
         loadUserLocations()
         loadGroupInfo()
         startMonitoringInputLocations()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        Log.d("LocationInput", "onResume: Checking for Fragment Result")
+        
+        // Fragment가 다시 나타날 때 Fragment Result를 확인
+        // 1. currentBackStackEntry의 savedStateHandle 확인
+        findNavController().currentBackStackEntry?.savedStateHandle?.get<Bundle>(CurrentLocationFragment.RESULT_KEY)?.let { bundle ->
+            Log.d("LocationInput", "Fragment result found in currentBackStackEntry savedStateHandle: $bundle")
+            findNavController().currentBackStackEntry?.savedStateHandle?.remove<Bundle>(CurrentLocationFragment.RESULT_KEY)
+            handleConfirmedLocation(bundle)
+            return@onResume
+        }
+        
+        // 2. previousBackStackEntry의 savedStateHandle 확인
+        findNavController().previousBackStackEntry?.savedStateHandle?.get<Bundle>(CurrentLocationFragment.RESULT_KEY)?.let { bundle ->
+            Log.d("LocationInput", "Fragment result found in previousBackStackEntry savedStateHandle: $bundle")
+            findNavController().previousBackStackEntry?.savedStateHandle?.remove<Bundle>(CurrentLocationFragment.RESULT_KEY)
+            handleConfirmedLocation(bundle)
+            return@onResume
+        }
+        
+        Log.d("LocationInput", "onResume: No Fragment Result found in savedStateHandle")
     }
 
     override fun onDestroyView() {
@@ -157,7 +187,37 @@ class LocationInputFragment : Fragment() {
             loadWorkLocation()
         }
 
-        // 검색창 클릭
+        // 검색창 EditText 클릭 (ProfileSetupFragment처럼 동작)
+        rootView?.findViewById<EditText>(R.id.et_search_address)?.apply {
+            setOnClickListener {
+                if (isLocationInputLocked()) {
+                    Toast.makeText(requireContext(), "중간값 계산이 완료되어 위치를 변경할 수 없습니다.", Toast.LENGTH_SHORT).show()
+                    return@setOnClickListener
+                }
+                openPlacesAutocomplete()
+            }
+            isFocusable = false
+            keyListener = null
+        }
+        
+        // 돋보기 아이콘 클릭 (검색창 내부 ImageView)
+        // layoutSearchBar의 첫 번째 자식이 ImageView (돋보기)
+        rootView?.findViewById<View>(R.id.layoutSearchBar)?.let { searchBarLayout ->
+            if (searchBarLayout is android.view.ViewGroup && searchBarLayout.childCount > 0) {
+                val searchIcon = searchBarLayout.getChildAt(0)
+                if (searchIcon is ImageView) {
+                    searchIcon.setOnClickListener {
+                        if (isLocationInputLocked()) {
+                            Toast.makeText(requireContext(), "중간값 계산이 완료되어 위치를 변경할 수 없습니다.", Toast.LENGTH_SHORT).show()
+                            return@setOnClickListener
+                        }
+                        openPlacesAutocomplete()
+                    }
+                }
+            }
+        }
+        
+        // 검색창 전체 레이아웃 클릭 (기존 동작 유지)
         rootView?.findViewById<View>(R.id.layoutSearchBar)?.setOnClickListener {
             if (isLocationInputLocked()) {
                 Toast.makeText(requireContext(), "중간값 계산이 완료되어 위치를 변경할 수 없습니다.", Toast.LENGTH_SHORT).show()
@@ -251,9 +311,21 @@ class LocationInputFragment : Fragment() {
     }
 
     private fun handleConfirmedLocation(bundle: Bundle) {
+        Log.d("LocationInput", "handleConfirmedLocation called with bundle: $bundle")
+        Log.d("LocationInput", "handleConfirmedLocation: rootView = $rootView")
+        
+        if (rootView == null) {
+            Log.e("LocationInput", "handleConfirmedLocation: rootView is null, cannot update UI")
+            // rootView가 null이면 나중에 다시 시도하기 위해 savedStateHandle에 저장
+            findNavController().currentBackStackEntry?.savedStateHandle?.set(CurrentLocationFragment.RESULT_KEY, bundle)
+            return
+        }
+        
         @Suppress("UNCHECKED_CAST")
         val locationMap = bundle
             .getSerializable(CurrentLocationFragment.EXTRA_LOCATION_DATA) as? Map<String, Any>
+
+        Log.d("LocationInput", "handleConfirmedLocation: locationMap = $locationMap")
 
         // lat/lng를 분리해서 받아서 LatLng 객체 생성
         val lat = (locationMap?.get("lat") as? Number)?.toDouble()
@@ -261,12 +333,23 @@ class LocationInputFragment : Fragment() {
         val address = locationMap?.get("address") as? String ?: ""
         val name = locationMap?.get("name") as? String ?: ""
 
+        Log.d("LocationInput", "handleConfirmedLocation: lat=$lat, lng=$lng, address=$address, name=$name")
+
         if (lat != null && lng != null) {
             selectedLocation = LatLng(lat, lng)
-            selectedAddress = address
-            selectedLocationType = "confirmed"
+            // name을 우선으로 사용, 없으면 address 사용
+            selectedAddress = name.ifBlank { address }.ifBlank { "주소 정보 없음" }
+            selectedLocationType = "current" // 현재 위치로 설정
 
+            Log.d("LocationInput", "handleConfirmedLocation: selectedLocation=$selectedLocation, selectedAddress=$selectedAddress, selectedLocationType=$selectedLocationType")
+            
             updateSelectedLocationUI()
+            
+            Log.d("LocationInput", "handleConfirmedLocation: UI updated, showing toast")
+            Toast.makeText(requireContext(), "위치가 선택되었습니다.", Toast.LENGTH_SHORT).show()
+        } else {
+            Log.e("LocationInput", "handleConfirmedLocation: lat or lng is null")
+            Toast.makeText(requireContext(), "위치 정보를 가져올 수 없습니다.", Toast.LENGTH_SHORT).show()
         }
     }
 
@@ -427,7 +510,7 @@ class LocationInputFragment : Fragment() {
     private fun openPlacesAutocomplete() {
         try {
             val fields = listOf(Place.Field.ID, Place.Field.NAME, Place.Field.LAT_LNG, Place.Field.ADDRESS)
-            val intent = Autocomplete.IntentBuilder(AutocompleteActivityMode.FULLSCREEN, fields)
+            val intent = Autocomplete.IntentBuilder(AutocompleteActivityMode.OVERLAY, fields)
                 .build(requireContext())
             autocompleteLauncher.launch(intent)
         } catch (e: Exception) {
@@ -439,6 +522,10 @@ class LocationInputFragment : Fragment() {
     private fun handleSelectedPlace(place: Place, type: String) {
         val latLng = place.latLng
         if (latLng != null) {
+            // 검색창 EditText에 선택된 장소 이름 표시 (ProfileSetupFragment처럼)
+            val addressText = place.name ?: place.address ?: "선택된 장소"
+            rootView?.findViewById<EditText>(R.id.et_search_address)?.setText(addressText)
+            
             // CurrentLocationFragment로 Navigation
             findNavController().navigate(
                 R.id.currentLocationFragment,

--- a/app/src/main/java/com/moyeoyo/app/ui/notification/NotificationFragment.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/notification/NotificationFragment.kt
@@ -213,7 +213,7 @@ class NotificationFragment : Fragment() {
                     }
 
                     // 🔵 그룹 관련 알림 → 그룹 상세로 이동
-                    "time_vote", "location_input", "final_vote", "finalized", "ranking" -> {
+                    "time_vote", "location_input", "final_vote", "finalized", "ranking", "reminder" -> {
                         if (item.groupId == null || item.groupId.isBlank()) {
                             Log.e("NotificationFragment", "그룹 ID가 없습니다. 알림 ID: ${item.id}, 타입: ${item.type}")
                             Toast.makeText(

--- a/app/src/main/java/com/moyeoyo/app/ui/notification/NotificationFragment.kt
+++ b/app/src/main/java/com/moyeoyo/app/ui/notification/NotificationFragment.kt
@@ -214,10 +214,11 @@ class NotificationFragment : Fragment() {
 
                     // 🔵 그룹 관련 알림 → 그룹 상세로 이동
                     "time_vote", "location_input", "final_vote", "finalized", "ranking" -> {
-                        if (item.groupId == null) {
+                        if (item.groupId == null || item.groupId.isBlank()) {
+                            Log.e("NotificationFragment", "그룹 ID가 없습니다. 알림 ID: ${item.id}, 타입: ${item.type}")
                             Toast.makeText(
                                 requireContext(),
-                                "그룹 정보를 찾을 수 없습니다.", Toast.LENGTH_SHORT
+                                "그룹 정보를 찾을 수 없습니다. 알림에 그룹 ID가 포함되지 않았습니다.", Toast.LENGTH_LONG
                             ).show()
                             return@setOnClickListener
                         }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3,7 +3,7 @@ import {
   onDocumentCreated,
   onDocumentUpdated
 } from "firebase-functions/v2/firestore";
-import { onSchedule } from "firebase-functions/v2/scheduler";
+// import { onSchedule } from "firebase-functions/v2/scheduler"; // ⚠️ DEPRECATED: 로컬 알림으로 대체됨
 
 /* ------------------------------------------------------
   Admin SDK 초기화 (Node 22 + Functions v2 필수)
@@ -204,55 +204,57 @@ export const onGroupStatusChanged = onDocumentUpdated(
 
 /* ------------------------------------------------------
   3) 약속 전날 알림
+  ⚠️ DEPRECATED: 로컬 알림으로 대체됨
+  약속 확정 시 앱에서 직접 로컬 알림을 스케줄링합니다.
 -------------------------------------------------------*/
-export const appointmentReminder = onSchedule("0 9 * * *", async () => {
-  const today = new Date();
-  const tomorrow = new Date(today);
-  tomorrow.setDate(today.getDate() + 1);
+// export const appointmentReminder = onSchedule("0 9 * * *", async () => {
+//   const today = new Date();
+//   const tomorrow = new Date(today);
+//   tomorrow.setDate(today.getDate() + 1);
 
-  const start = new Date(tomorrow.setHours(0, 0, 0));
-  const end = new Date(tomorrow.setHours(23, 59, 59));
+//   const start = new Date(tomorrow.setHours(0, 0, 0));
+//   const end = new Date(tomorrow.setHours(23, 59, 59));
 
-  const snap = await db
-    .collection("groups")
-    .where("confirmedTime", ">=", start)
-    .where("confirmedTime", "<=", end)
-    .get();
+//   const snap = await db
+//     .collection("groups")
+//     .where("confirmedTime", ">=", start)
+//     .where("confirmedTime", "<=", end)
+//     .get();
 
-  for (const doc of snap.docs) {
-    const data = doc.data();
-    const memberUids = data.memberUids ?? [];
+//   for (const doc of snap.docs) {
+//     const data = doc.data();
+//     const memberUids = data.memberUids ?? [];
 
-    const groupName = data.groupName ?? "모임";
+//     const groupName = data.groupName ?? "모임";
 
-    // 약속 시간 포맷팅
-    const confirmedTime = data.confirmedTime?.toDate?.() ?? null;
-    let timeText = "";
-    if (confirmedTime) {
-      const hours = confirmedTime.getHours().toString().padStart(2, "0");
-      const minutes = confirmedTime.getMinutes().toString().padStart(2, "0");
-      timeText = `${hours}:${minutes}`;
-    }
+//     // 약속 시간 포맷팅
+//     const confirmedTime = data.confirmedTime?.toDate?.() ?? null;
+//     let timeText = "";
+//     if (confirmedTime) {
+//       const hours = confirmedTime.getHours().toString().padStart(2, "0");
+//       const minutes = confirmedTime.getMinutes().toString().padStart(2, "0");
+//       timeText = `${hours}:${minutes}`;
+//     }
 
-    // 장소 정보
-    const placeName =
-          typeof data.confirmedPlace === "string"
-            ? data.confirmedPlace
-            : data.confirmedPlace?.name ?? "장소 미정";
+//     // 장소 정보
+//     const placeName =
+//           typeof data.confirmedPlace === "string"
+//             ? data.confirmedPlace
+//             : data.confirmedPlace?.name ?? "장소 미정";
 
-    // 알림 메시지 생성
-    const reminderMessage =
-          `내일 '${groupName}' 일정이 있어요!\n` +
-          `${placeName}` + (timeText ? ` / ${timeText}` : "");
+//     // 알림 메시지 생성
+//     const reminderMessage =
+//           `내일 '${groupName}' 일정이 있어요!\n` +
+//           `${placeName}` + (timeText ? ` / ${timeText}` : "");
 
-    await sendPushToMembers(
-          memberUids,
-          "🔔 내일 약속이 있어요!",
-          reminderMessage,
-          {
-            type: "reminder",
-            groupId: doc.id
-          }
-    );
-  }
-});
+//     await sendPushToMembers(
+//           memberUids,
+//           "🔔 내일 약속이 있어요!",
+//           reminderMessage,
+//           {
+//             type: "reminder",
+//             groupId: doc.id
+//           }
+//     );
+//   }
+// });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -142,6 +142,7 @@ export const onGroupStatusChanged = onDocumentUpdated(
 
     const memberUids = after.memberUids ?? [];
     const groupName = after.groupName ?? "모임";
+    const groupId = event.params.groupId; // 그룹 ID 가져오기
 
     switch (newStatus) {
       case "TIME_VOTE_REQUIRED":
@@ -149,7 +150,7 @@ export const onGroupStatusChanged = onDocumentUpdated(
           memberUids,
           "⏰ 시간 투표 요청",
           `${groupName} 모임이 만들어졌습니다! 가능한 시간을 투표해주세요.`,
-          { type: "time_vote" }
+          { type: "time_vote", groupId: groupId }
         );
         break;
 
@@ -158,7 +159,7 @@ export const onGroupStatusChanged = onDocumentUpdated(
           memberUids,
           "🕒 최종 시간 투표",
           "최종 약속 일정을 투표해주세요!",
-          { type: "location_input" }
+          { type: "location_input", groupId: groupId }
         );
         break;
 
@@ -167,7 +168,7 @@ export const onGroupStatusChanged = onDocumentUpdated(
           memberUids,
           "📍 시간 투표 완료!",
           `${groupName}의 약속 일정이 확정되었습니다. 이제 출발 위치를 입력해주세요.`,
-          { type: "location_input" }
+          { type: "location_input", groupId: groupId }
         );
         break;
 
@@ -176,7 +177,7 @@ export const onGroupStatusChanged = onDocumentUpdated(
           memberUids,
           "✨ 장소 순위 투표 시작",
           "중간 지점 계산 완료! 주변 장소를 보고 순위를 투표해주세요.",
-          { type: "ranking" }
+          { type: "ranking", groupId: groupId }
         );
         break;
 
@@ -185,7 +186,7 @@ export const onGroupStatusChanged = onDocumentUpdated(
           memberUids,
           "🔥 최종 장소 투표",
           "마지막으로 최종 약속 장소를 투표해주세요!",
-          { type: "final_vote" }
+          { type: "final_vote", groupId: groupId }
         );
         break;
 
@@ -194,7 +195,7 @@ export const onGroupStatusChanged = onDocumentUpdated(
           memberUids,
           "🎉 약속 장소 확정!",
           `${groupName}의 약속 장소가 확정되었습니다.`,
-          { type: "finalized" }
+          { type: "finalized", groupId: groupId }
         );
         break;
     }


### PR DESCRIPTION
## 주요 변경사항

### 1. 로컬 리마인더 알림 구현
- **로컬 알림으로 전환**: Cloud Functions 기반 푸시 알림에서 클라이언트 측 로컬 알림으로 변경
- **알림 시점**: 약속 전날 같은 시간에 알림 (예: 12일 1시 약속 → 11일 1시 알림)
- **데이터 소스**: Firebase 우선 조회, 실패 시 RoomDB 폴백
- **인앱 알림 연동**: 로컬 알림도 Firestore에 알림 문서 생성하여 인앱 알림창에 표시
- **스케줄 관리**: 약속 확정/수정 시 자동으로 기존 알림 취소 후 재스케줄링

### 2. 푸시 알림 클릭 처리 개선
- **자동 읽음 처리**: 그룹 관련 알림 클릭 시 자동으로 읽음 처리
- **네비게이션 개선**:
  - 그룹 관련 알림 (시간 투표, 장소 투표, 약속 확정 등) → 해당 그룹 상세 화면으로 이동
  - 친구 요청 알림 → 인앱 알림창으로 이동
- **Intent 데이터 전달**: `groupId`, `notificationType`을 Intent에 포함하여 정확한 화면 이동

### 3. 위치 선택 기능 수정
- **프로필 설정**: 현재 위치 선택 시 주소가 검색창에 표시되고 저장되도록 수정
- **LocationInputFragment**: 검색창을 오버레이 모드로 변경하고, 검색창/돋보기 아이콘 클릭 시 장소 검색 화면 표시
- **Fragment Result 통신**: `requireActivity().supportFragmentManager`를 사용하여 Fragment 간 데이터 전달 안정화

## 변경된 파일

### Android
- `MainActivity.kt`: 알림 Intent 처리 로직 추가
- `FirebaseMessagingService.kt`: 로컬 알림 스케줄링 및 Intent 데이터 전달
- `LocalNotificationScheduler.kt`: 로컬 알림 스케줄링 로직 (신규)
- `ReminderNotificationReceiver.kt`: 알림 수신 및 표시 (신규)
- `NotificationRepository.kt`: 자동 읽음 처리 및 로컬 알림 문서 생성 메서드 추가
- `GroupRepository.kt`: 약속 확정/수정 시 로컬 알림 스케줄링 연동
- `ProfileSetupFragment.kt`: 위치 데이터 수신 및 저장 로직 개선
- `LocationInputFragment.kt`: 검색창 UI/UX 개선 및 Fragment Result 수신 개선
- `CurrentLocationFragment.kt`: Fragment Result 전달 로직 개선
- `NotificationFragment.kt`: 리마인더 알림 타입 처리 추가
- `NextMeetingDao.kt`: groupId로 조회 메서드 추가
- `AndroidManifest.xml`: 알림 관련 권한 및 Receiver 등록

### Cloud Functions
- `index.ts`: 리마인더 푸시 알림 함수 제거, 그룹 관련 알림에 `groupId` 데이터 추가

## 기술 스택
- Android AlarmManager (로컬 알림 스케줄링)
- BroadcastReceiver (알림 수신)
- RoomDB (로컬 데이터 저장)
- Firebase Firestore (알림 문서 관리)
